### PR TITLE
Tag version numbers in github

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -14,7 +14,7 @@ env:
 phases:
   pre_build:
     commands:
-      - export ES_SCRIPT_HOME="$CODEBUILD_SRC_DIR/scripts/earsketch-deployment/scripts"
+      - export ES_SCRIPT_HOME="$CODEBUILD_SRC_DIR/config/deployment-scripts"
       - export LOCAL_STAGING_DIR_NAME="${CODEBUILD_SOURCE_VERSION//\//-}"
       - export LOCAL_STAGING_DIR="$CODEBUILD_SRC_DIR/$LOCAL_STAGING_DIR_NAME"
       - export ES_VERSION="$ES_VERSION_MAJOR.$ES_VERSION_MINOR.$CODEBUILD_BUILD_NUMBER"
@@ -43,6 +43,16 @@ phases:
       - echo "Copying the client files to local distribution folder..."
       - cp -r index.html sc.html sorry.html favicon.ico tunepadESLogin.html tpBody.html autograder/ autograder2/ autograder3/ css/ ExportToReaper/ fonts/ img/ scripts/ templates/ dist/ "$LOCAL_STAGING_DIR"
       # - python "$ES_SCRIPT_HOME/github_create_deployment.py" $GITHUB_USER $GITHUB_TOKEN $CODEBUILD_RESOLVED_SOURCE_VERSION $LOCAL_STAGING_DIR_NAME
+  post_build:
+    commands:
+      - |
+        if [$ES_BUILD_ENVIRONMENT = "production"] 
+        then
+          echo "Tagging production build with version $ES_VERSION"
+          python "$ES_SCRIPT_HOME/github_create_release.py" $GITHUB_USER $GITHUB_TOKEN $CODEBUILD_RESOLVED_SOURCE_VERSION $ES_VERSION
+        else
+          echo "Not applying git tag. Non-production environment: $ES_BUILD_ENVIRONMENT"
+        fi
 artifacts:
   files:
     - '**/*'

--- a/config/deployment-scripts/github_create_release.py
+++ b/config/deployment-scripts/github_create_release.py
@@ -1,0 +1,31 @@
+import sys
+import json
+import requests
+from requests.auth import HTTPBasicAuth
+
+if len(sys.argv) < 5:
+    print("Error, no arguments given")
+    print("Usage: github_create_release.py <GIT_USER> <GITHUB_TOKEN> <GIT_COMMIT_SHA> <NEW_VERSION_NUMBER>")
+    exit(1)
+github_user = sys.argv[1]
+github_token = sys.argv[2]
+git_commit_sha = sys.argv[3]
+new_version_number = sys.argv[4]
+
+url = "https://api.github.com/repos/GTCMT/earsketch-webclient/"
+headers = {'Accept': 'application/vnd.github.v3+json'}
+auth = HTTPBasicAuth(github_user,github_token)
+
+createReleaseParams = {"target_commitish":git_commit_sha,
+                          "tag_name": "v"+new_version_number
+                          }
+r = requests.post(url + "releases", headers=headers, auth=auth, json=createReleaseParams)
+newRelease = r.json()
+try:
+    r.raise_for_status()
+except requests.exceptions.HTTPError:
+    print("Create Release HTTP Error Exception message: " + newRelease["message"])
+    sys.exit()
+
+print('New GitHub Releaes id: {}'.format(newRelease["id"]))
+


### PR DESCRIPTION
New GitHub script to add version number release tags with the build number from AWS  CodeBuild. For production builds only.