### PR TITLE
Don't wrap lines of code in API usage examples.

### DIFF
--- a/scripts/src/browser/API.js
+++ b/scripts/src/browser/API.js
@@ -39,7 +39,7 @@ export class CodeHighlight extends Component {
 
     render() {
         const { language, children } = this.props
-        return <code ref={this.codeNode} className={language}>{children}</code>
+        return <code ref={this.codeNode} className={`${language} whitespace-pre`}>{children}</code>
     }
 }
 


### PR DESCRIPTION
Closes GTCMT/earsketch#2148; can be deferred until we have more changes to deploy.

Tested in Chrome and Firefox.