### PR TITLE
Update to take host and path as single uri build parameter

### DIFF
--- a/config/buildspec.yml
+++ b/config/buildspec.yml
@@ -6,7 +6,7 @@ env:
     ENV_FLAGS_FILE: /earsketch-webclient/BuildConfig/$ES_BUILD_ENVIRONMENT/npm-env-flags-file
     ES_VERSION_MAJOR: /earsketch-webclient/version_number/major
     ES_VERSION_MINOR: /earsketch-webclient/version_number/minor
-    ES_HOST: /earsketch-webclient/BuildConfig/$ES_BUILD_ENVIRONMENT/client_host
+    ES_BASE_URI: /earsketch-webclient/BuildConfig/$ES_BUILD_ENVIRONMENT/client_base_uri
   secrets-manager:
     GITHUB_USER: Github_EarSketch_CICD_Credentials:github_user
     GITHUB_TOKEN: Github_EarSketch_CICD_Credentials:github_token
@@ -30,7 +30,7 @@ phases:
       - end_time="$(date -u +%s)" && elapsed="$(($end_time-$start_time))" && echo "Total of $elapsed seconds elapsed for build"
       - grunt less
       - end_time="$(date -u +%s)" && elapsed="$(($end_time-$start_time))" && echo "Total of $elapsed seconds elapsed for build"
-      - npm run $NPM_BUILD_COMMAND -- --env.release=$ES_VERSION --env.flags=config/$ENV_FLAGS_FILE --env.host=$ES_HOST
+      - npm run $NPM_BUILD_COMMAND -- --env.release=$ES_VERSION --env.flags=config/$ENV_FLAGS_FILE --env.baseuri=$ES_BASE_URI
       - end_time="$(date -u +%s)" && elapsed="$(($end_time-$start_time))" && echo "Total of $elapsed seconds elapsed for build"
       - mkdir $LOCAL_STAGING_DIR
       - mkdir $LOCAL_STAGING_CACHED_DIR

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -12,8 +12,7 @@ module.exports = env => {
     const target = (env && env.target) ? env.target : 'prod';
     const apiHost = target==='prod' ? 'https://api.ersktch.gatech.edu' : 'https://earsketch-dev.lmc.gatech.edu';
     const webSocketURL = apiHost.replace('http', 'ws') + (target==='prod' ? '/EarSketchWS' : '/websocket');
-    const clientHost = (env && env.host) ? env.host : 'https://earsketch.gatech.edu';
-    const clientPath = (env && env.path) ? env.path : 'earsketch2';
+    const clientBaseURI = (env && env.baseuri) ? env.baseuri : 'https://earsketch.gatech.edu/earsketch2';
     const release = (env && env.release) ? env.release : Date.now();
 
     return merge(common, {
@@ -34,7 +33,7 @@ module.exports = env => {
                 URL_SEARCHFREESOUND: JSON.stringify(`${apiHost}/EarSketchWS/services/audio/searchfreesound`),
                 URL_SAVEFREESOUND: JSON.stringify(`${apiHost}/EarSketchWS/services/files/uploadfromfreesound`),
                 URL_LOADAUDIO: JSON.stringify(`${apiHost}/EarSketchWS/services/audio/getaudiosample`),
-                SITE_BASE_URI: JSON.stringify(`${clientHost}/${clientPath}`)
+                SITE_BASE_URI: JSON.stringify(`${clientBaseURI}`)
             }),
             new CleanWebpackPlugin()
         ],


### PR DESCRIPTION
This will allow for different deploy paths for the CAI builds in a single parameter, instead of separate parameters for host and path