### PR TITLE
Autograder Fix: Include curriculum data

### DIFF
--- a/autograder/index.template.html
+++ b/autograder/index.template.html
@@ -49,7 +49,9 @@
 
 </head>
 <body ng-controller="autograderController" ng-cloak>
-
+<script type="text/javascript" src="/curriculum/curr_toc.js"></script>
+<script type="text/javascript" src="/curriculum/curr_pages.js"></script>
+<script type="text/javascript" src="/curriculum/curr_searchdoc.js"></script>
     <div class="container">
       <h1>EarSketch Autograder</h1>
 

--- a/autograder2/index.template.html
+++ b/autograder2/index.template.html
@@ -49,7 +49,9 @@
 
 </head>
 <body ng-controller="autograder2Controller" ng-cloak>
-
+<script type="text/javascript" src="/curriculum/curr_toc.js"></script>
+<script type="text/javascript" src="/curriculum/curr_pages.js"></script>
+<script type="text/javascript" src="/curriculum/curr_searchdoc.js"></script>
     <div class="container">
       <h1>EarSketch Autograder</h1>
 

--- a/autograder3/index.template.html
+++ b/autograder3/index.template.html
@@ -49,7 +49,9 @@
 
 </head>
 <body ng-controller="autograder3Controller" ng-cloak>
-
+<script type="text/javascript" src="/curriculum/curr_toc.js"></script>
+<script type="text/javascript" src="/curriculum/curr_pages.js"></script>
+<script type="text/javascript" src="/curriculum/curr_searchdoc.js"></script>
   <div class="container">
     <h1>EarSketch Autograder 3</h1>
 

--- a/autograderAWS/index.template.html
+++ b/autograderAWS/index.template.html
@@ -49,7 +49,9 @@
 
 </head>
 <body ng-controller="autograderAWSController" ng-cloak>
-
+<script type="text/javascript" src="/curriculum/curr_toc.js"></script>
+<script type="text/javascript" src="/curriculum/curr_pages.js"></script>
+<script type="text/javascript" src="/curriculum/curr_searchdoc.js"></script>
   <div class="container">
 
       <h1>EarSketch Autograder</h1>


### PR DESCRIPTION
Including curriculum data files is required because the curriculum browser is included in the bundle. We should perhaps find a way to conditionally remove it for pages that don't require it, like the auto graders.