### PR TITLE
Fix splitter image paths in CSS 

### DIFF
--- a/css/earsketch/splitter.less
+++ b/css/earsketch/splitter.less
@@ -4,14 +4,14 @@
 /* Angular UI Layout Splitter */
 .ui-layout-column > .ui-splitbar{
 	z-index:23;
-	background-image: url(/img/splitter-v.png);
+	background-image: url(../../img/splitter-v.png);
 	background-repeat:  repeat-x;
 	background-position: center;
 }
 
 .ui-layout-row > .ui-splitbar {
 	z-index:23;
-	background-image: url(/img/splitter.png);
+	background-image: url(../../img/splitter.png);
 	background-repeat: repeat-y;
 	background-position: center;
 }
@@ -143,7 +143,7 @@
 	/* border: 1px solid #BBB; */ /* match pane-border */
 	opacity: .70;
 		filter:  alpha(opacity=70);
-	background:url(/img/splitter.png) repeat;
+	background:url(../../img/splitter.png) repeat;
 	/*background-color: #BBB;*/ 
 	}
 	.ui-layout-toggler-north ,
@@ -152,7 +152,7 @@
 	}
 	.ui-layout-toggler-west ,
 	.ui-layout-toggler-east {
-		background:url(/img/splitter-v.png) repeat;
+		background:url(../../img/splitter-v.png) repeat;
 		/* background-color: #BBB; */
 		/* border-width: 1px 0; *//* top/bottom borders */
 	}

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -27,7 +27,14 @@ module.exports = env => {
         module: {
             rules: [{
                 test: /\.less$/,
-                use: [MiniCssExtractPlugin.loader,'css-loader','less-loader']
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            publicPath: clientBaseURI + '/dist'
+                        }
+                    },
+                    'css-loader','less-loader']
             }]
         },
         plugins: [


### PR DESCRIPTION
Paths were broken for production build because site is embedded in /earsketch2