### PR TITLE
Fix bugs related to temporary local scripts and invalid share ID

### DIFF
--- a/scripts/src/app/services/userProject.js
+++ b/scripts/src/app/services/userProject.js
@@ -360,22 +360,21 @@ app.factory('userProject', ['$rootScope', '$http', 'ESUtils', 'esconsole', '$win
 
                 resetOpenScripts();
 
-                $q.all(promises).then(function (savedScripts) {
-                    refreshCodeBrowser().then(function () {
+                return $q.all(promises).then(function (savedScripts) {
+                    localStorage.remove(LS_SCRIPTS_KEY);
+                    localStorage.remove(LS_TABS_KEY);
+
+                    return refreshCodeBrowser().then(function () {
                         // once all scripts have been saved open them
                         angular.forEach(savedScripts, function(savedScript) {
                             openScript(savedScript.shareid);
                         });
                     });
-                });
-
-                localStorage.remove(LS_SCRIPTS_KEY);
-                localStorage.remove(LS_TABS_KEY);
+                }).then(() => getSharedScripts(username, password));
+            } else {
+                // load scripts in shared browser
+                return getSharedScripts(username, password);
             }
-
-            // load scripts in shared browser
-            return getSharedScripts(username, password);
-
         }, function(err) {
             esconsole('Login failure', ['DEBUG','ERROR']);
             esconsole(err.toString(), ['DEBUG','ERROR']); // TODO: this shows as [object object]?


### PR DESCRIPTION
The particular bug where the user could see / share invalid script IDs like xxxx0000 is now fixed. Local scripts with temporary ID were not converted to real ones with `saveScript` API when the user had no previous scripts stored on server. 

Also, an unrelated bug where local scripts were not showing up in the script browser after logging in was fixed.