### PR TITLE
fix embedMode hide-editor option not working

### DIFF
--- a/scripts/src/app/ideController.js
+++ b/scripts/src/app/ideController.js
@@ -687,6 +687,8 @@ app.controller("ideController", ['$rootScope', '$scope', '$http', '$uibModal', '
     };
 
     colorTheme.subscribe($scope, function (event, theme) {
+        if (!$scope.editor.ace) return;
+
         if (theme === 'dark') {
             $scope.editor.ace.setTheme('ace/theme/monokai');
         } else {

--- a/scripts/src/app/layoutController.js
+++ b/scripts/src/app/layoutController.js
@@ -275,7 +275,7 @@ app.controller('layoutController', ['layout', '$rootScope', '$scope', '$timeout'
      */
     postDigest(function () {
         var editorScope = angular.element('.code-container').scope();
-        if (editorScope) {
+        if (editorScope && editorScope.editor.droplet) {
             editorScope.editor.droplet.resize();
         }
     });

--- a/scripts/src/app/mainController.js
+++ b/scripts/src/app/mainController.js
@@ -73,6 +73,8 @@ app.controller("mainController", ['$rootScope', '$scope', '$state', '$http', '$u
     var trustedHtml = {};
 
     $scope.isEmbedded = $location.search()["embedded"] === "true";
+    $scope.hideDAW = $scope.isEmbedded && $location.search()['hideDaw'];
+    $scope.hideEditor = $scope.isEmbedded && $location.search()['hideCode'];
     $scope.embeddedScriptName = '';
 
     if ($scope.isEmbedded) {
@@ -80,11 +82,21 @@ app.controller("mainController", ['$rootScope', '$scope', '$state', '$http', '$u
         $ngRedux.dispatch(appState.setEmbedMode(true));
         Layout.destroy();
         layout.setMinSize(0);
+
+        if ($scope.hideEditor) {
+            layout.setGutterSize(0);
+        }
         Layout.initialize();
         $ngRedux.dispatch(layout.collapseWest());
         $ngRedux.dispatch(layout.collapseEast());
         $ngRedux.dispatch(layout.collapseSouth());
-        $ngRedux.dispatch(layout.setNorthFromRatio([25,75,0]));
+
+        if ($scope.hideEditor) {
+            // Note: hideDAW-only currently does not fit the layout height to the DAW player height as the below API only supports ratios.
+            $ngRedux.dispatch(layout.setNorthFromRatio([100,0,0]));
+        } else {
+            $ngRedux.dispatch(layout.setNorthFromRatio([25,75,0]));
+        }
     } else {
         userProject.loadLocalScripts();
         $ngRedux.dispatch(scripts.syncToNgUserProject());

--- a/scripts/src/layout/Layout.js
+++ b/scripts/src/layout/Layout.js
@@ -13,7 +13,7 @@ export const toggleHorizontalDrag = (index, state) => {
 
 export const initialize = () => {
     const horizontalSplits = Split(['#sidebar-container','#content','#curriculum-container'], {
-        gutterSize: 8,
+        gutterSize: layout.getGutterSize(),
         minSize: layout.getMinSize(),
         snapOffset: 0,
         sizes: layout.selectHorizontalRatio(store.getState()),
@@ -25,7 +25,7 @@ export const initialize = () => {
         },
         gutterStyle() {
             return {
-                width: '8px',
+                width: `${layout.getGutterSize()}px`,
                 cursor: 'col-resize'
             }
         },
@@ -36,7 +36,7 @@ export const initialize = () => {
 
     const verticalSplits = Split(['#devctrl','#coder','#console-frame'], {
         direction: 'vertical',
-        gutterSize: 8,
+        gutterSize: layout.getGutterSize(),
         minSize: layout.getMinSize(),
         sizes: layout.selectVerticalRatio(store.getState()),
         snapOffset: 0,
@@ -54,7 +54,7 @@ export const initialize = () => {
         gutterStyle(dimension, gutterSize) {
             return {
                 'flex-basis': gutterSize + 'px',
-                height: '8px',
+                height: `${layout.getGutterSize()}px`,
                 cursor: 'row-resize'
             }
         },

--- a/scripts/src/layout/layoutState.js
+++ b/scripts/src/layout/layoutState.js
@@ -70,7 +70,8 @@ const windowHeight = () => window.innerHeight|| document.documentElement.clientH
 const layoutMutableState = {
     horizontalSplits: null,
     verticalSplits: null,
-    minSize: horizontalMinSize
+    minSize: horizontalMinSize,
+    gutterSize: 8
 };
 
 export const setHorizontalSplits = ref => {
@@ -86,8 +87,13 @@ export const getVerticalSplits = () => layoutMutableState.verticalSplits;
 
 export const setMinSize = size => {
     layoutMutableState.minSize = size;
-}
+};
 export const getMinSize = () => layoutMutableState.minSize;
+
+export const setGutterSize = size => {
+    layoutMutableState.gutterSize = size;
+};
+export const getGutterSize = () => layoutMutableState.gutterSize;
 
 export const isWestOpen = state => state.layout.west.open;
 export const isEastOpen = state => state.layout.east.open;

--- a/templates/index.html
+++ b/templates/index.html
@@ -255,7 +255,7 @@
                             </div>
                         </div>
 
-                        <div class="split flex flex-col" id="coder" ng-style="{'z-index':bubble.active&&[1,2,9].includes(bubble.currentPage)?35:0}" ng-controller="tabController">
+                        <div class="split flex flex-col" id="coder" ng-style="{'z-index':bubble.active&&[1,2,9].includes(bubble.currentPage)?35:0}" ng-controller="tabController" ng-show="!hideEditor">
                             <editor-header></editor-header>
 
                             <div class="flex-grow h-full overflow-y-hidden">


### PR DESCRIPTION
The hideDAW option is not addressed but should still work fine -- The option does hide the DAW render result but cannot set the north-grid height to the player height when editor is shown.