### PR TITLE
Make code examples without paste button legible

### DIFF
--- a/css/earsketch/theme_dark.less
+++ b/css/earsketch/theme_dark.less
@@ -507,6 +507,7 @@ a,
 }
 
 #curriculum pre {
+  color: #f8f8f2;
   background-color: #23241f !important; 
   border: 1px solid @selected-bg;
 }


### PR DESCRIPTION
Adds color to code examples where a paste/import button is not desired