### PR TITLE
Fix blocks share bug

### DIFF
--- a/scripts/src/editor/EditorHeader.js
+++ b/scripts/src/editor/EditorHeader.js
@@ -98,7 +98,7 @@ const EditorHeader = () => {
                     )
                 }
                 {
-                    (loggedIn && scriptType !== 'readonly' && !script.collaborative) && (
+                    (loggedIn && scriptType !== 'readonly' && !(scriptType === 'shared' && script.collaborative)) && (
                         <div
                             className={`
                                 rounded-full


### PR DESCRIPTION
This includes:
- Prevention of sharing from the editor header with shared, collaborative (not owned), or read-only (curriculum) scripts
- Fix for the editor share button saving the script with old-state (as loaded into the script browser) script content.