### PR TITLE
Editor/IDE Language Interpretation

### DIFF
--- a/scripts/src/ide/Editor.tsx
+++ b/scripts/src/ide/Editor.tsx
@@ -13,6 +13,7 @@ import { initEditor } from "./IDE"
 import * as tabs from "./tabState"
 import * as userConsole from "./console"
 import * as userProject from "../app/userProject"
+import * as ESUtils from "../esutils"
 import store from "../reducers"
 
 const COLLAB_COLORS = [[255, 80, 80], [0, 255, 0], [255, 255, 50], [100, 150, 255], [255, 160, 0], [180, 60, 255]]
@@ -114,7 +115,7 @@ let lineNumber: number | null = null
 let marker: number | null = null
 
 export function highlightError(err: any) {
-    const language = tabs.selectActiveTabScript(store.getState())?.name.split('.')[1] === "py" ? "python" : "javascript"
+    const language = ESUtils.parseLanguage(tabs.selectActiveTabScript(store.getState()).name)
     let range
 
     let line = language === "python" ? err.traceback?.[0]?.lineno : err.lineNumber
@@ -262,7 +263,7 @@ export const Editor = () => {
     const fontSize = useSelector(appState.selectFontSize)
     const blocksMode = useSelector(editor.selectBlocksMode)
     const editorElement = useRef<HTMLDivElement>(null)
-    const language = activeScript?.name.split('.')[1] === "py" ? "python" : "javascript"
+    const language = ESUtils.parseLanguage(activeScript?.name ?? ".py")
 
     useEffect(() => {
         if (!editorElement.current) return

--- a/scripts/src/ide/IDE.tsx
+++ b/scripts/src/ide/IDE.tsx
@@ -267,7 +267,7 @@ export async function compileCode() {
     const code = editor.getValue()
 
     const startTime = Date.now()
-    const language = tabs.selectActiveTabScript(store.getState())?.name.split('.')[1] === "py" ? "python" : "javascript"
+    const language = ESUtils.parseLanguage(tabs.selectActiveTabScript(store.getState()).name)
 
     editor.clearErrors()
     ideConsole.clear()
@@ -368,7 +368,7 @@ export async function compileCode() {
 
 export const IDE = () => {
     const dispatch = useDispatch()
-    const language = useSelector(tabs.selectActiveTabScript)?.name.split('.')[1] === "py" ? "python" : "javascript"
+    const language = useSelector(appState.selectScriptLanguage)
     const numTabs = useSelector(tabs.selectOpenTabs).length
 
     const embedMode = useSelector(appState.selectEmbedMode)


### PR DESCRIPTION
* Use active script's language, not appState.
Fixes GTCMT/earsketch/issues/2477.