### PR TITLE
Safari DAW-related visual fixes.

### DIFF
--- a/scripts/src/daw/DAW.tsx
+++ b/scripts/src/daw/DAW.tsx
@@ -968,7 +968,7 @@ export const DAW = () => {
         <Header playPosition={playPosition} setPlayPosition={setPlayPosition}></Header>
 
         {!hideDAW &&
-        <div id="zoom-container" className="flex-grow relative w-full h-full flex flex-col overflow-x-auto overflow-y-hidden">
+        <div id="zoom-container" className="flex-grow relative w-full h-full flex flex-col overflow-x-auto overflow-y-hidden z-0">
             {/* Effects Toggle */}
             <button className="btn-effect flex items-center justify-center bg-white hover:bg-blue-100 dark:text-white dark:bg-gray-900 dark:hover:bg-blue-500"
                     title={t('daw.tooltip.toggleEffects')} onClick={() => dispatch(daw.toggleEffects())} disabled={!hasEffects}>

--- a/scripts/src/ide/Editor.tsx
+++ b/scripts/src/ide/Editor.tsx
@@ -333,7 +333,7 @@ export const Editor = () => {
         }
     }, [scriptID])
 
-    return <div className="flex flex-grow h-full max-h-full overflow-y-hidden">
+    return <div className="flex flex-grow h-full max-h-full overflow-y-hidden" style={{ WebkitTransform: "translate3d(0,0,0)" }}>
         <div ref={editorElement} id="editor" className="code-container">
             {/* import button */}
             {activeScript?.readonly && !embedMode


### PR DESCRIPTION
Webkit transformations and manual z-index setting to fix effects and S/M button visibility issues.

Fixes https://github.com/GTCMT/earsketch/issues/2484 and fixes https://github.com/GTCMT/earsketch/issues/2468.