### PR TITLE
Don't open all shared scripts upon login.

### DIFF
--- a/scripts/src/app/userProject.ts
+++ b/scripts/src/app/userProject.ts
@@ -364,7 +364,11 @@ export async function login(username: string, password: string) {
         }
     }
 
-    await Promise.all(Object.keys(sharedScripts).map(openShare))
+    const shareID = ESUtils.getURLParameter("sharing")
+    if (shareID && sharedScripts[shareID]) {
+        // User opened share link, and they haven't imported or deleted the shared script.
+        await openShare(shareID)
+    }
 
     // load scripts in shared browser
     return getSharedScripts()


### PR DESCRIPTION
Fixes GTCMT/earsketch#2518.
Hopefully doesn't break things that #179 fixed.