### PR TITLE
Tweak comma-dangle, no-use-before-define rules.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     rules: {
         "no-use-before-define": "off",
         "@typescript-eslint/no-use-before-define": ["error", { functions: false, variables: false, classes: false }],
+        "@typescript-eslint/type-annotation-spacing": ["error"],
         "space-before-function-paren": ["error", { named: "never" }],
         "comma-dangle": ["error", {
             arrays: "always-multiline",


### PR DESCRIPTION
Rationale:

**comma-dangle off for functions:** functions are usually not variadic, and including the trailing comma just invites confusion about the number and position of arguments. The comma is especially awkward for functions often used with a single multiline argument, as in the uses of `map` that are common in our React components.

**no-use-before-define off for upper scopes:** because this should be allowed:
```js
function f() {
    g()
}

function g() {
    return 17
}
```
(This comes up particularly often in our Redux state modules, which tend to export all the reducers after defining the slice and sometimes thunks.)

If anyone else has tweaks they want to get in, feel free to suggest them for this PR.