### PR TITLE
Use the same EarSketch spinner everywhere.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,14 +6,11 @@
     <title>EarSketch</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <style>
-        .loading-spinner {
-            border-radius: 50%;
-            border: 16px solid #4286DA;
-            border-left-color: #f3f3f3;
-            border-right-color: #f3f3f3;
-            width: 120px;
-            height: 120px;
-            animation: spin 2s linear infinite;
+        .es-spinner {
+            background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" version="1.1" id="svg8" viewBox="0 0 120 120"%3E%3Cstyle id="style959"/%3E%3Cg id="layer1" transform="translate(-30 -30)" fill-opacity="1" stroke-width="1"%3E%3Cpath id="path931" d="M46 90H30a60 60 0 0060 60v-16a44 44 0 01-44-44z" fill="%234286da"/%3E%3Cpath id="path953" d="M90 30a60 60 0 00-60 60h16a44 44 0 0144-44V30z" fill="%23f3f3f3"/%3E%3Cpath id="path950" d="M150 90h-16a44 44 0 01-44 44v16a60 60 0 0060-60z" fill="%23f3f3f3"/%3E%3Cpath id="path956" d="M90 30v16a44 44 0 0144 44h16a60 60 0 00-60-60z" fill="%234286da"/%3E%3C/g%3E%3C/svg%3E');
+            width: 1em;
+            height: 1em;
+            display: inline-block;
         }
 
         @keyframes spin {
@@ -47,7 +44,7 @@
     <div id="root"></div>
     <div id="loading-screen" style="z-index: 999; position: absolute; top: 0; left: 0; bottom: 0; right: 0; padding-bottom: 30vh; display: flex; flex-direction: column; align-items: center; justify-content: center; background: white">
         <div style="font-size: 3rem; padding-bottom: 4rem">Loading EarSketch...</div>
-        <div class="loading-spinner"></div>
+        <div class="es-spinner" style="width: 120px; height: 120px; animation: spin 2s linear infinite"></div>
     </div>
     <script>
         // Since React is loaded later, CSS file swapping will be too late to change the color of the loading screen.

--- a/scripts/src/app/Download.tsx
+++ b/scripts/src/app/Download.tsx
@@ -53,7 +53,7 @@ export const Download = ({ script, quality, close }: { script: Script, quality: 
                 <div className="col-md-1">
                     <h3>
                         {loading[type as keyof typeof EXPORT_TYPES]
-                        ? <i className="inline-block animate-spin icon icon-spinner" />
+                        ? <i className="animate-spin es-spinner" />
                         : <a href="#" onClick={e => { e.preventDefault(); save(type as keyof typeof EXPORT_TYPES) }}>
                             <i className="glyphicon glyphicon-download-alt" />
                         </a>}

--- a/scripts/src/app/ScriptHistory.tsx
+++ b/scripts/src/app/ScriptHistory.tsx
@@ -154,7 +154,7 @@ export const ScriptHistory = ({ script, allowRevert, close }: { script: Script, 
                 ? <div className="col-md-8 scroll-50 relative"><DAW /></div>
                 : (compiling
                 ? <div className="col-md-8 scroll-50">
-                    <i className="animate-spin inline-block icon icon-spinner"></i> {t('scriptHistory.running')}
+                    <i className="animate-spin es-spinner"></i> {t('scriptHistory.running')}
                 </div>
                 : <div className="col-md-8 scroll-50">
                     <pre><Diff original={original?.source_code ?? ""} modified={modified?.source_code ?? ""} /></pre>

--- a/scripts/src/app/ScriptShare.tsx
+++ b/scripts/src/app/ScriptShare.tsx
@@ -424,7 +424,7 @@ const SoundCloudTab = ({ script, licenses, licenseID, setLicenseID, description,
             <MoreDetails {...{ licenses, licenseID, setLicenseID, description, setDescription }} />
 
             {message && <div className="text-center" style={{ height: "3em", lineHeight: "3em", textAlign: "center", backgroundColor: "rgb(170,255,255,0.5)" }}>
-                {message.startsWith("UPLOADING") && <i className="inline-block animate-spin spinner icon icon-spinner"></i>} {message}
+                {message.startsWith("UPLOADING") && <i className="animate-spin es-spinner"></i>} {message}
             </div>}
 
             <div className="text-right" style={{ height: "3em", lineHeight: "3em" }}>

--- a/scripts/src/app/SoundUploader.tsx
+++ b/scripts/src/app/SoundUploader.tsx
@@ -357,7 +357,7 @@ const FreesoundTab = ({ close }: { close: () => void }) => {
                     </div>)}
                 </div>}
             {searched &&
-                (results === null && <div><i className="inline-block animate-spin icon icon-spinner" />{t('soundUploader.freesound.searching')}</div>
+                (results === null && <div><i className="animate-spin es-spinner mr-3" />{t('soundUploader.freesound.searching')}</div>
                     || results!.length === 0 && <div>{t('noResults')}</div>)}
             <div className="modal-section-header"><span>{t('soundUploader.constantRequired')}</span></div>
             <input type="text" placeholder="e.g. MYSOUND_01" className="form-control" value={key} onChange={e => setKey(cleanKey(e.target.value))} required />

--- a/scripts/src/browser/Curriculum.tsx
+++ b/scripts/src/browser/Curriculum.tsx
@@ -259,7 +259,7 @@ const CurriculumPane = () => {
                         ? <article ref={curriculumBody} id="curriculum-body" className="prose dark:prose-dark px-8 h-full max-w-none overflow-y-auto" style={{ fontSize }} />
                         : <div className="flex flex-col items-center">
                             <div className="text-4xl text-center py-16">Loading curriculum...</div>
-                            <div className="loading-spinner" style={{ width: "90px", height: "90px", borderWidth: "9px" }} />
+                            <div className="animate-spin es-spinner" style={{ width: "90px", height: "90px" }} />
                         </div>}
                 </div>
             </div>

--- a/scripts/src/browser/Sounds.tsx
+++ b/scripts/src/browser/Sounds.tsx
@@ -180,7 +180,7 @@ const Clip: React.FC<{ clip: SoundEntity, bgcolor: string }> = ({ clip, bgcolor 
                         title={t("soundBrowser.clip.tooltip.previewSound")}
                     >
                         {previewFileKey === fileKey
-                        ? (previewNode ? <i className="icon icon-stop2" /> : <i className="animate-spin inline-block icon-spinner" />)
+                        ? (previewNode ? <i className="icon icon-stop2" /> : <i className="animate-spin es-spinner" />)
                         : <i className="icon icon-play4" />
                         }
                     </button>

--- a/scripts/src/ide/IDE.tsx
+++ b/scripts/src/ide/IDE.tsx
@@ -427,7 +427,7 @@ export const IDE = () => {
                         <div className="h-full max-h-full relative" id="workspace" style={bubbleActive && [3,4,9].includes(bubblePage) ? { zIndex: 35 } : {}}>
                             {loading
                             ? <div className="loading text-center h-full w-full flex items-center justify-center">
-                                <i className="spinner icon icon-spinner inline-block animate-spin mr-3"></i> Loading...
+                                <i className="es-spinner animate-spin mr-3"></i> Loading...
                             </div>
                             : <div className="workstation h-full w-full"><DAW /></div>}
                         </div>


### PR DESCRIPTION
This switches away from the funny and slightly misanimated bubble
spinner to the recognizable ES loading spinner (already used for startup
and curriculum).
This also makes it easier to scale the ES loading spinner by rendering
it as an SVG rather than using CSS border tricks.