### PR TITLE
Clean up AccountCreator.

### DIFF
--- a/scripts/src/app/AccountCreator.tsx
+++ b/scripts/src/app/AccountCreator.tsx
@@ -5,7 +5,7 @@ import * as userNotification from "../user/notification"
 import { post } from "./userProject"
 import { useTranslation } from "react-i18next"
 
-export const AccountCreator = ({ close }: { close: (value?: any) => void }) => {
+export const AccountCreator = ({ close }: { close: (value?: { username: string, password: string }) => void }) => {
     const [error, setError] = useState("")
     const [username, setUsername] = useState("")
     const [password, setPassword] = useState("")
@@ -14,9 +14,7 @@ export const AccountCreator = ({ close }: { close: (value?: any) => void }) => {
     const { t } = useTranslation()
 
     const submit = async () => {
-        setError("Please wait...")
         try {
-            // TODO: This endpoint is poorly named - it creates new accounts.
             const data = await post("/users/create", {
                 username,
                 email,
@@ -44,43 +42,23 @@ export const AccountCreator = ({ close }: { close: (value?: any) => void }) => {
         <form onSubmit={e => { e.preventDefault(); submit() }}>
             <div className="modal-body">
                 {error && <div className="alert alert-danger">{error}</div>}
-                <div className="row">
-                    <div className="col-md-12">
-                        <div className="form-group">
-                            <input type="text" className="form-control" name="username" placeholder={t("formfieldPlaceholder.username")} value={username} onChange={e => setUsername(e.target.value)} required maxLength={25} pattern="[a-zA-Z_][0-9a-zA-Z_]*" title={t("messages:createaccount.usernameconstraint")} />
-                        </div>
-                    </div>
+                <input type="text" className="form-control mb-4" name="username" placeholder={t("formfieldPlaceholder.username")} value={username} onChange={e => setUsername(e.target.value)} required maxLength={25} pattern="[a-zA-Z_][0-9a-zA-Z_]*" title={t("messages:createaccount.usernameconstraint")} />
+
+                <div className="flex">
+                    <input type="password" className="form-control mb-4 mr-2" name="password" placeholder={t("formfieldPlaceholder.password")} value={password} onChange={e => setPassword(e.target.value)} required minLength={5} />
+
+                    <input type="password" className="form-control mb-4 ml-2" name="passwordconfirm" placeholder={t("formfieldPlaceholder.confirmPassword")} onChange={e => {
+                        e.target.setCustomValidity(e.target.value === password ? "" : t("messages:createaccount.pwdfail"))
+                        setConfirmPassword(e.target.value)
+                    }} value={confirmPassword} required />
                 </div>
 
-                <div className="row">
-                    <div className="col-md-6">
-                        <div className="form-group">
-                            <input type="password" className="form-control" name="password" placeholder={t("formfieldPlaceholder.password")} value={password} onChange={e => setPassword(e.target.value)} required minLength={5} />
-                        </div>
-                    </div>
-
-                    <div className="col-md-6">
-                        <div className="form-group">
-                            <input type="password" className="form-control" name="passwordconfirm" placeholder={t("formfieldPlaceholder.confirmPassword")} onChange={e => {
-                                e.target.setCustomValidity(e.target.value === password ? "" : t("messages:createaccount.pwdfail"))
-                                setConfirmPassword(e.target.value)
-                            }} value={confirmPassword} required />
-                        </div>
-                    </div>
-                </div>
-
-                <div className="row">
-                    <div className="col-md-12">
-                        <div className="form-group">
-                            <input type="email" className="form-control" name="email" placeholder={t("formFieldPlaceholder.emailOptional")} value={email} onChange={e => setEmail(e.target.value)} />
-                        </div>
-                    </div>
-                </div>
+                <input type="email" className="form-control" name="email" placeholder={t("formFieldPlaceholder.emailOptional")} value={email} onChange={e => setEmail(e.target.value)} />
             </div>
 
             <div className="modal-footer">
-                <input type="button" className="btn btn-default" onClick={() => close()} value={t("cancel") as string} />
-                <input type="submit" className="btn btn-primary" value={t("accountCreator.submit") as string} />
+                <input type="button" className="btn btn-default" onClick={() => close()} value={t("cancel").toLocaleUpperCase()} />
+                <input type="submit" className="btn btn-primary" value={t("accountCreator.submit").toLocaleUpperCase()} />
             </div>
         </form>
     </>


### PR DESCRIPTION
- Remove superfluous "Please wait..." message.
- Remove unnecessary Bootstrap `<div>`s.
- Capitalize button text for UI consistency.
- Remove resolved TODO about endpoint naming.

Fixes GTCMT/earsketch#2576.