### PR TITLE
Improvements to Python/JS APIs, optional init.

### DIFF
--- a/scripts/src/api/passthrough.ts
+++ b/scripts/src/api/passthrough.ts
@@ -35,10 +35,8 @@ class InternalError extends Error {
     }
 }
 
-// Set the initial state of the result object.
+// Generate initial result object.
 export const init = () => {
-    esconsole("Calling pt_init from passthrough", "PT")
-
     return {
         init: true,
         finish: false,
@@ -52,8 +50,6 @@ export const init = () => {
 // Set the tempo on the result object.
 export function setTempo(result: DAWData, tempo: number) {
     esconsole("Calling pt_setTempo from passthrough with parameter " + tempo, ["DEBUG", "PT"])
-
-    checkInit(result)
 
     const args = [...arguments].slice(1) // remove first argument
     ptCheckArgs("setTempo", args, 1, 1)
@@ -74,8 +70,6 @@ export function setTempo(result: DAWData, tempo: number) {
 export const finish = (result: DAWData) => {
     esconsole("Calling pt_finish from passthrough", "PT")
 
-    checkInit(result)
-
     // We used to set a flag here. But all the flag indicated was whether the user called this function,
     // and this function didn't actually do anything *except* set that flag.
     return result
@@ -84,8 +78,6 @@ export const finish = (result: DAWData) => {
 // Add a clip to the given result object.
 export function fitMedia(result: DAWData, filekey: string, trackNumber: number, startLocation: number, endLocation: number) {
     esconsole(`Calling pt_fitMedia from passthrough with parameters ${filekey}, ${trackNumber}, ${startLocation}, ${endLocation}`, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1) // remove first argument
     ptCheckArgs("fitMedia", args, 4, 4)
@@ -124,8 +116,6 @@ export function insertMedia(result: DAWData, fileName: string, trackNumber: numb
         trackNumber + " , " +
         trackLocation + " , " +
         scaleAudio, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1) // remove first argument
     ptCheckArgs("insertMedia", args, 3, 4)
@@ -188,8 +178,6 @@ export function insertMediaSection(
         mediaEndLocation + " , " +
         scaleAudio, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("insertMediaSection", args, 3, 6)
     ptCheckType("fileName", "string", fileName)
@@ -246,8 +234,6 @@ export function makeBeat(result: DAWData, media: any, track: number, measure: nu
         measure + " , " +
         beatString,
         "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("makeBeat", args, 4, 4)
@@ -355,8 +341,6 @@ export function makeBeatSlice(result: DAWData, media: string, track: number, mea
         beatNumber,
         "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("makeBeatSlice", args, 5, 5)
     ptCheckType("media", "string", media)
@@ -444,8 +428,6 @@ export function analyze(result: DAWData, audioFile: string, featureForAnalysis: 
         featureForAnalysis,
         "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("analyze", args, 2, 2)
 
@@ -485,8 +467,6 @@ export function analyzeForTime(result: DAWData, audioFile: string, featureForAna
         endTime,
         "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("analyzeForTime", args, 4, 4)
 
@@ -523,8 +503,6 @@ export function analyzeForTime(result: DAWData, audioFile: string, featureForAna
 
 export function analyzeTrack(result: DAWData, trackNumber: number, featureForAnalysis: string) {
     esconsole(`Calling pt_analyzeTrack from passthrough with parameters ${trackNumber}, ${featureForAnalysis}`, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("analyzeTrack", args, 2, 2)
@@ -573,8 +551,6 @@ export function analyzeTrackForTime(result: DAWData, trackNumber: number, featur
         endTime,
         "PT"
     )
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("analyzeTrackForTime", args, 4, 4)
@@ -637,8 +613,6 @@ export function dur(result: DAWData, fileKey: string) {
     esconsole("Calling pt_dur from passthrough with parameters " +
                 fileKey, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("dur", args, 1, 1)
     ptCheckType("fileKey", "string", fileKey)
@@ -658,8 +632,6 @@ export function gauss(result: DAWData, mean: number, stddev: number) {
         stddev,
         "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("gauss", args, 0, 2)
 
@@ -675,8 +647,6 @@ export function importImage(result: DAWData, imageURL: string, nrows: number, nc
         ncols + " , " +
         color,
         "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("importImage", args, 3, 4)
@@ -712,8 +682,6 @@ export function importImage(result: DAWData, imageURL: string, nrows: number, nc
 
 export function importFile(result: DAWData, fileURL: string) {
     esconsole("Calling pt_importFile from passthrough with parameters " + fileURL, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("importFile", args, 1, 1)
@@ -753,8 +721,6 @@ export function println(result: DAWData, msg: string) {
 export function readInput(result: DAWData, msg: string) {
     esconsole("Calling pt_readInput from passthrough with parameter " + msg, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("readInput", args, 0, 1)
     msg = msg ?? ""
@@ -770,8 +736,6 @@ export function replaceListElement(result: DAWData, inputList: any[], elementToR
         elementToReplace + " , " +
         withElement,
         "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("replaceListElement", args, 3, 3)
@@ -798,8 +762,6 @@ export function replaceString(result: DAWData, patternString: string, characterT
         withElement,
         "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("replaceString", args, 3, 3)
     ptCheckType("patternString", "string", patternString)
@@ -819,8 +781,6 @@ export function replaceString(result: DAWData, patternString: string, characterT
 export function reverseList(result: DAWData, inputList: any[]) {
     esconsole("Calling pt_reverseList from passthrough with parameters " + inputList, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("reverseList", args, 1, 1)
     ptCheckType("inputList", "array", inputList)
@@ -832,8 +792,6 @@ export function reverseList(result: DAWData, inputList: any[]) {
 // Reverse a string.
 export function reverseString(result: DAWData, inputString: string) {
     esconsole("Calling pt_reverseString from passthrough with parameters " + inputString, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("reverseString", args, 1, 1)
@@ -854,8 +812,6 @@ export function rhythmEffects(
 ) {
     esconsole("Calling pt_rhythmEffects from passthrough with parameters " +
         [track, effectType, effectParameter, effectList, measure, beatString].join(", "), "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("rhythmEffects", args, 6, 6)
@@ -941,8 +897,6 @@ export function setEffect(
     esconsole("Calling pt_setEffect from passthrough with parameters " +
         [trackNumber, effect, parameter, effectStartValue, effectStartLocation, effectEndValue, effectEndLocation].join(", "), "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("setEffect", args, 2, 7)
     ptCheckType("trackNumber", "number", trackNumber)
@@ -1025,8 +979,6 @@ export function createAudioSlice(result: DAWData, oldSoundFile: string, startLoc
 export function selectRandomFile(result: DAWData, folder: string, extension: undefined | string = undefined) {
     esconsole(`Calling pt_selectRandomFile from passthrough with parameters ${folder}, ${extension}`, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("selectRandomFile", args, 1, 2)
     ptCheckType("folder", "string", folder)
@@ -1065,8 +1017,6 @@ export function selectRandomFile(result: DAWData, folder: string, extension: und
 export function shuffleList(result: DAWData, array: any[]) {
     esconsole(`Calling pt_shuffleList from passthrough with parameters ${array}`, "PT")
 
-    checkInit(result)
-
     const args = [...arguments].slice(1)
     ptCheckArgs("shuffleList", args, 1, 1)
     ptCheckType("inputList", "array", array)
@@ -1088,8 +1038,6 @@ export function shuffleList(result: DAWData, array: any[]) {
 // Shuffle a string.
 export function shuffleString(result: DAWData, inputString: string) {
     esconsole(`Calling pt_shuffleString from passthrough with parameters ${inputString}`, "PT")
-
-    checkInit(result)
 
     const args = [...arguments].slice(1)
     ptCheckArgs("shuffleString", args, 1, 1)
@@ -1234,12 +1182,6 @@ const ptCheckEffectRange = (
     if (res !== true) {
         const error = new RangeError(parameter + " is out of range")
         throw error
-    }
-}
-
-function checkInit(result: DAWData) {
-    if (typeof result !== "object" || result.init !== true) {
-        throw new Error("init() is missing")
     }
 }
 

--- a/scripts/src/app/player.ts
+++ b/scripts/src/app/player.ts
@@ -64,7 +64,6 @@ export interface DAWData {
     length: number
     tracks: Track[]
     master: GainNode
-    init: boolean
     slicedClips: { [key: string]: ClipSlice }
 }
 


### PR DESCRIPTION
We live in a strange world. For instance, on prod,
```python
print "Hello world"
```
throws a obtuse error (the JS version throws a better-but-still-unnecessary error), while
```python
import earsketch

earsketch.init()
print(earsketch.__ES_RESULT)

earsketch.fitMedia(OS_SNARE03, 1, 1, 2)
print(earsketch.__ES_RESULT)

earsketch.__ES_RESULT["tracks"][1]["clips"][0]["filekey"] = "DUBSTEP_BASS_WOBBLE_001"
print(earsketch.__ES_RESULT)
```
works without a hitch... and actually swaps out the placed clip.

This PR does three things:
1. Stop putting our internal data (formerly called `__ES_RESULT`, which contains DAW data for eventual rendering) in the user code namespace. There is no reason to do this, and it allows users to circumvent the EarSketch API and write scripts that are very much liable to break in the future if we make internal changes, or break the client in strange ways today.
2. Make `init()` optional. Like `finish()`, `init()` is an artifact of EarSketch's old Reaper days. There is no technical need for it now, and it's just one more thing that students can get wrong (and one more mysterious line for newcomers). This is particularly unhelpful if a user is trying to start with some scripting that doesn't involve the EarSketch API; simply trying to print "Hello world" throws an error. Making it optional finishes the job started in #102, which made `finish()` optional.
3. Clean up relevant modules. In `earsketch.py.ts` and `earsketch.js.ts`, typecasts to `any` and a remnant of `__AUDIO_QUALITY` have been removed. In `passthrough.ts`, the many invocations of `checkInit()` have been removed because they are no longer necessary.

Before we merge this, we should search the database to ensure that no user scripts (that aren't mine) use `__ES_RESULT`. This seems unlikely, and we probably don't want to support it even if they do (because the internal structure of DAW data is not a part of our API).