### PR TITLE
Recommender fix follow-up.

### DIFF
--- a/scripts/src/app/App.tsx
+++ b/scripts/src/app/App.tsx
@@ -243,6 +243,7 @@ export function reloadRecommendations() {
             }
         }
     }
+    // If there are no samples to use for recommendation, just use something random so the window isn't blank.
     if (input.length === 0) {
         input = recommender.addRandomRecInput(input)
     }


### PR DESCRIPTION
Following up on #249, this removes everything but the core fix.
(The core fix was re-adding the separate comment check.)
This also:
- Fixes a slow check in `generateRecommendations` innermost loop.
- Adds a TODO for fixing up how we scrape for recommender inputs.
- Adds an explanatory comment for the fix for the existing blank window bug in #249.

Fixes GTCMT/earsketch#2596.