### PR TITLE
Update browser version check

### DIFF
--- a/scripts/src/esutils.ts
+++ b/scripts/src/esutils.ts
@@ -73,7 +73,7 @@ export const whichBrowser = () => {
 
         M = M[2] ? [M[1], M[2]] : [window.navigator.appName, window.navigator.appVersion, "-?"]
 
-        if ((tem = ua.match(/version\/(\d+)/i)) !== null) {
+        if ((tem = ua.match(/version\/(\d+\.?\d*)/i)) !== null) {
             M.splice(1, 1, tem[1])
         }
     }

--- a/scripts/src/index.tsx
+++ b/scripts/src/index.tsx
@@ -75,7 +75,7 @@ if (window.navigator.appName === "Microsoft Internet Explorer") {
 
 // Check for minimum version of Chrome/Firefox. TODO: Update?
 const M = ESUtils.whichBrowser().split(" ")
-if ((M[0] === "Chrome" && +M[1] < 24) || (M[0] === "Firefox" && +M[1] < 25)) {
+if ((M[0] === "Chrome" && +M[1] < 43) || (M[0] === "Firefox" && +M[1] < 25) || (M[0] === "Safari" && +M[1] < 14.1)) {
     alert("It appears you are using version " + M[1] + " of " + M[0] + ". Please upgrade your browser so that EarSketch functions properly.")
 }
 


### PR DESCRIPTION
Increase chrome version to match AudioBuffer.copyToChannel support (`>= 43`).

Add Safari check to math use of AudioBuffer.copyToChannel support (`>= 14.1`).

Adds minor version number to regex.

AudioBuffer.copyToChannel supported version matrix: https://caniuse.com/mdn-api_audiobuffer_copytochannel