### PR TITLE
Limit default zoom for short projects.

### DIFF
--- a/scripts/src/daw/DAW.tsx
+++ b/scripts/src/daw/DAW.tsx
@@ -658,7 +658,9 @@ export function setDAWData(result: player.DAWData) {
         dispatch(daw.setSoloMute({}))
         dispatch(daw.setBypass({}))
         // Set zoom based on play length.
-        dispatch(daw.setTrackWidth(64000 / playLength))
+        // (The `max()` puts a cap on zoom when dealing with a small number of measures.)
+        const trackWidth = 64000 / Math.max(playLength, 8)
+        dispatch(daw.setTrackWidth(trackWidth))
         dispatch(daw.setTrackHeight(45))
         lastTab = state.tabs.activeTabID
         // Get updated state after dispatches:


### PR DESCRIPTION
Fixes GTCMT/earsketch#2626.

Adds an upper limit on default zoom levels.
As @manodrum described in GTCMT/earsketch#2626, the extreme level of zoom for short lengths (as happen the user is just starting a new project) can cause confusion when the user adds more measures.
To fix this, the DAW rounds the project length up to 8 for the purposes of picking a default zoom level.
(We avoid resetting the zoom while the user is working on the project, because that may conflict with their zoom adjustments.)

New default zoom with different project lengths:
- 0 measures
![image](https://user-images.githubusercontent.com/99575/151596996-6a8992b5-72d2-4c07-8c00-8913a03071c2.png)
- 1 measure
![image](https://user-images.githubusercontent.com/99575/151597111-8dfd8213-384b-4c53-8b7f-eeb2781ddf8a.png)
- 2 measures
![image](https://user-images.githubusercontent.com/99575/151597506-e531b01d-d4b6-4d4f-83fe-be1aa28d5b95.png)
- 4 measures
![image](https://user-images.githubusercontent.com/99575/151597270-b15e5a1b-d921-4a5d-b1a9-2070da7df17a.png)
- 8 measures
![image](https://user-images.githubusercontent.com/99575/151597334-c94eb2c7-57fc-489e-b1a7-4790e47d47e3.png)
- 16 measures
![image](https://user-images.githubusercontent.com/99575/151597444-b308fc5f-15c4-46db-8213-d304ed8a70aa.png)

Old behavior for comparison:
- 0 measures
![image](https://user-images.githubusercontent.com/99575/151597880-f2efe3ef-5d3f-45ca-a9e2-3b76d13b4027.png)
- 1 measure
![image](https://user-images.githubusercontent.com/99575/151597994-2394984e-d820-4eae-89f7-f38b6ccec205.png)
- 2 measures
![image](https://user-images.githubusercontent.com/99575/151598179-96ce4fc8-b186-4ce1-b6c0-c1560dfef0ae.png)
- 4 measures
![image](https://user-images.githubusercontent.com/99575/151597796-1e214ddd-cc00-41ea-803e-29046e2c181d.png)

(Default zoom level is the same for projects that are 8+ measures.)