### PR TITLE
Include client version in API requests

### DIFF
--- a/scripts/src/app/userProject.ts
+++ b/scripts/src/app/userProject.ts
@@ -44,8 +44,9 @@ async function fetchAPI(endpoint: string, init?: RequestInit) {
         ...init,
         headers: {
             ...init?.headers,
+            // add custom headers here
             "X-EarSketch-Version": `${BUILD_NUM}`.split("-")[0],
-        }, // add custom headers here
+        },
     }
     try {
         const response = await fetch(URL_DOMAIN + endpoint, init)


### PR DESCRIPTION
Adding a custom HTTP header `X-EarSketch-Version` to API requests.

In the short term this will be used to investigate whether certain "bad" client versions are spamming our server.