### PR TITLE
Remove karma-html-reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8881,24 +8881,6 @@
         }
       }
     },
-    "karma-html-reporter": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/karma-html-reporter/-/karma-html-reporter-0.2.7.tgz",
-      "integrity": "sha1-/XPanxrJn9W6+zCc8HCUIYjnumM=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.2.0",
-        "mu2": "~0.5.19"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz",
-          "integrity": "sha1-ypNf0UqzwMhyq6zxmLnNpQFECGc=",
-          "dev": true
-        }
-      }
-    },
     "karma-jasmine": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-4.0.1.tgz",
@@ -9801,12 +9783,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mu2": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/mu2/-/mu2-0.5.21.tgz",
-      "integrity": "sha1-iIqPD9kOsc/anbgUdvbhmcyeWNM=",
       "dev": true
     },
     "multicast-dns": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "jasmine-core": "^2.3.4",
     "karma": "^6.3.16",
     "karma-chrome-launcher": "^3.1.0",
-    "karma-html-reporter": "^0.2.7",
     "karma-jasmine": "^4.0.1",
     "karma-junit-reporter": "^2.0.1",
     "karma-sourcemap-loader": "^0.3.8",

--- a/tests/integration/scripts/scripts.conf.js
+++ b/tests/integration/scripts/scripts.conf.js
@@ -26,7 +26,6 @@ module.exports = function (config) {
         plugins: [
             "karma-chrome-launcher",
             "karma-jasmine",
-            "karma-html-reporter",
             "karma-webpack",
             "karma-junit-reporter",
         ],
@@ -36,7 +35,7 @@ module.exports = function (config) {
         browserDisconnectTolerance: 3,
         browserNoActivityTimeout: 120000,
 
-        reporters: ["progress", "html", "junit"],
+        reporters: ["progress", "junit"],
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,


### PR DESCRIPTION
this library is no longer maintained and depends on a vulnerable version of lodash. We also don't use the html reports anymore. 

This should close another 7 Dependabot alerts.