### PR TITLE
Fix Scripts/Sounds list background color stutter on scroll

### DIFF
--- a/scripts/src/browser/Scripts.tsx
+++ b/scripts/src/browser/Scripts.tsx
@@ -373,9 +373,10 @@ const WindowedScriptCollection = ({ title, entities, scriptIDs, type, visible = 
                         const ID = scriptIDs[index]
                         return (
                             <div style={style}
-                                className="bg-gray-300 odd:bg-white
-                                           dark:bg-gray-800 dark:odd:bg-gray-900
-                                           hover:bg-blue-200 dark:hover:bg-blue-500">
+                                className={index % 2 === 0
+                                    ? "bg-white dark:bg-gray-900"
+                                    : "bg-gray-300 dark:bg-gray-800" +
+                                    " hover:bg-blue-200 dark:hover:bg-blue-500"}>
                                 <ScriptEntry key={ID} script={entities[ID]} type={type} />
                             </div>
                         )

--- a/scripts/src/browser/Sounds.tsx
+++ b/scripts/src/browser/Sounds.tsx
@@ -358,9 +358,10 @@ const WindowedSoundCollection = ({ title, folders, namesByFolders, visible = tru
                             const names = namesByFolders[folders[index]]
                             return (
                                 <div style={style}
-                                    className="bg-gray-300 odd:bg-white
-                                               dark:bg-gray-800 dark:odd:bg-gray-900
-                                               hover:bg-blue-200 dark:hover:bg-blue-500">
+                                    className={index % 2 === 0
+                                        ? "bg-white dark:bg-gray-900"
+                                        : "bg-gray-300 dark:bg-gray-800" +
+                                         " hover:bg-blue-200 dark:hover:bg-blue-500"}>
                                     <Folder
                                         folder={folders[index]}
                                         names={names}


### PR DESCRIPTION
Was relying on css `odd` child calculation, but since we only render the visible list items, a child's even/odd-ness changes depending on where you are in the scroll.

This resorts back to relying on list item's index to calculate even/odd-ness instead of DOM child position.