### PR TITLE
Hide play to prevent embedded mode race condition

### DIFF
--- a/scripts/src/daw/DAW.tsx
+++ b/scripts/src/daw/DAW.tsx
@@ -32,6 +32,7 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
     const loop = useSelector(daw.selectLoop)
     const autoScroll = useSelector(daw.selectAutoScroll)
     const embedMode = useSelector(appState.selectEmbedMode)
+    const embeddedScriptName = useSelector(appState.selectEmbeddedScriptName)
     const [embedCompiled, setEmbedCompiled] = useState(false)
     const needCompile = embedMode && !embedCompiled
     const { t } = useTranslation()
@@ -171,7 +172,8 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
 
             <span id="daw-play-button">
                 {/* Play */}
-                {!playing && <span className="daw-transport-button">
+                {/* Prevent embedded mode race condition by waiting for embeddedScriptName to populate before showing */}
+                {!playing && (!embedMode || (embedMode && embeddedScriptName)) && <span className="daw-transport-button">
                     <button aria-label={t("daw.tooltip.play")} type="submit" className={"btn hover:opacity-70 text-green-500" + (needCompile ? " flashButton" : "")} title={t("daw.tooltip.play")} onClick={() => { play(); addUIClick("project - play") }}>
                         <span className="icon icon-play4"></span>
                     </button>


### PR DESCRIPTION
In chrome it is possible to hit "play" before a script loads in embedded mode. This causes an exception which prevents the loading from completing.

To prevent this, we will wait for the script name to populate before showing the play button.

Addresses GTCMT/earsketch#2792