### PR TITLE
Prevent recording crash on Mac Firefox

### DIFF
--- a/scripts/src/app/SoundUploader.tsx
+++ b/scripts/src/app/SoundUploader.tsx
@@ -136,8 +136,9 @@ const FileTab = ({ close }: { close: () => void }) => {
 }
 
 const RecordTab = ({ close }: { close: () => void }) => {
+    const isMacFirefox = ESUtils.whichBrowser().includes("Firefox") && ESUtils.whichOS() === "MacOS"
     const [name, setName] = useState("")
-    const [error, setError] = useState("")
+    const [error, setError] = useState(isMacFirefox ? "Sorry, recording in EarSketch currently does not work in Firefox on Mac. Please use Chrome or Safari." : "")
     const [progress, setProgress] = useState<number>()
     const [buffer, setBuffer] = useState(null as AudioBuffer | null)
 
@@ -189,7 +190,7 @@ const RecordTab = ({ close }: { close: () => void }) => {
                 (error
                     ? <input type="button" className="btn btn-primary block m-auto" onClick={() => { setError(""); recorder.init() }} value={t("soundUploader.record.mic.reenable") as string} />
                     : t("soundUploader.record.mic.waiting"))}
-            {micReady && <div>
+            {micReady && !isMacFirefox && <div>
                 <div className="modal-section-header">
                     <span>{t("soundUploader.record.measures.title")}</span>
                     {metronome &&

--- a/scripts/src/app/SoundUploader.tsx
+++ b/scripts/src/app/SoundUploader.tsx
@@ -136,9 +136,10 @@ const FileTab = ({ close }: { close: () => void }) => {
 }
 
 const RecordTab = ({ close }: { close: () => void }) => {
+    const { t } = useTranslation()
     const isMacFirefox = ESUtils.whichBrowser().includes("Firefox") && ESUtils.whichOS() === "MacOS"
     const [name, setName] = useState("")
-    const [error, setError] = useState(isMacFirefox ? "Sorry, recording in EarSketch currently does not work in Firefox on Mac. Please use Chrome or Safari." : "")
+    const [error, setError] = useState(isMacFirefox ? t("soundUploader.record.firefoxMacError") : "")
     const [progress, setProgress] = useState<number>()
     const [buffer, setBuffer] = useState(null as AudioBuffer | null)
 
@@ -149,7 +150,6 @@ const RecordTab = ({ close }: { close: () => void }) => {
     const [measures, setMeasures] = useState(2)
     const [micReady, setMicReady] = useState(false)
     const [beat, setBeat] = useState(0)
-    const { t } = useTranslation()
 
     const startRecording = () => {
         recorder.properties.bpm = tempo

--- a/scripts/src/locales/en/common.json
+++ b/scripts/src/locales/en/common.json
@@ -226,6 +226,7 @@
     "clear": "Clear",
     "soundUploader.record.mic.waiting": "Waiting for microphone access...",
     "soundUploader.record.mic.reenable": "Enable mic and click here to try again.",
+    "soundUploader.record.firefoxMacError": "Sorry, recording in EarSketch currently does not work in Firefox on Mac. Please use Chrome or Safari.",
     "soundUploader.freesound.description": "is an online database of thousands of free audio clips, including everything from music to field recordings, all under Creative Commons licenses. You can search for clips on Freesound and save them to EarSketch below.",
     "soundUploader.freesound.searching": "Searching Freesound...",
     "soundUploader.freesound.uploadedBy": "Uploaded by Freesound user {{userName}}",


### PR DESCRIPTION
This is a tricky one to work around, and Firefox on Mac only made up 747 (0.29%) of our users over the past 12 months.

We could work around this by giving the microphone it's own audio context and then downsampling the input down to 44.1K with a custom Audio Worklet, but Firefox does not support inspection of the sample rate as part of fingerprint resistance, so it isn't clear how we could determine the source sample rate to downsample from.

Instead, this simply disables the Quick Record feature on Firefox for Mac so that at least the app doesn't crash (white screen).

Resolves GTCMT/earsketch#2659