### PR TITLE
Cypress test: Collapsible panes

### DIFF
--- a/tests/e2e-cypress/integration/panes.spec.js
+++ b/tests/e2e-cypress/integration/panes.spec.js
@@ -7,12 +7,34 @@ describe("Collapsible Panes", () => {
     })
 
     it("toggles panes", () => {
-        cy.get("button[title='Close Content Manager']").click() // close browser
-        cy.get("div[title='Open CONTENT MANAGER']").click() // re-open browser
-        cy.get("button[title='Close Content Manager']") // check if browser is open
+        // Test 1: Content Manager
 
-        cy.get("button[title='Close Curriculum']").click() // close curriculum
-        cy.get("div[title='Open CURRICULUM']").click() // re-open curriculum
-        cy.get("button[title='Close Curriculum']") // check if curriculum is open
+        // verify content manager pane shows the correct button when expanded
+        cy.get("div[title='Open CONTENT MANAGER']").should("not.exist")
+
+        // use button to close content manager
+        cy.get("button[title='Close Content Manager']").click()
+
+        // verify content manager pane shows the correct button when collapsed
+        cy.get("div[title='Open CONTENT MANAGER']")
+        cy.get("button[title='Close Content Manager']").should("not.be.visible")
+
+        // verify content manager pane has a narrow width when collapsed
+        cy.get("div#content-manager").invoke("outerWidth").should("be.lte", 45)
+
+        // Test 2: Curriculum
+
+        // verify curriculum pane shows the correct button when expanded
+        cy.get("div[title='Open CURRICULUM']").should("not.exist")
+
+        // use button to close curriculum
+        cy.get("button[title='Close Curriculum']").click()
+
+        // verify curriculum pane shows the correct button when collapsed
+        cy.get("div[title='Open CURRICULUM']")
+        cy.get("button[title='Close Curriculum']").should("not.exist")
+
+        // verify curriculum pane has a narrow width when collapsed
+        cy.get("div#curriculum-container").invoke("outerWidth").should("be.lte", 45)
     })
 })


### PR DESCRIPTION
Open, close, and check the collapsible browser and curriculum panes. _Note: the curriculum toggle has a chance to hit a "Resize observer limit reached" error._