### PR TITLE
Fix YVIP broken curriculum link

### DIFF
--- a/scripts/src/data/old_curriculum.ts
+++ b/scripts/src/data/old_curriculum.ts
@@ -288,4 +288,6 @@ export const OLD_CURRICULUM_LOCATIONS: { [index: string]: string } = {
     "/es/v2/anade-algunos-ritmos": "/es/v2/add-beats.html",
     "/es/v2/ciclos-y-lineas-musicales": "/es/v2/loops-and-layers.html",
     "/es/v2/efectos-y-envelopes": "/es/v2/effects-and-envelopes.html",
+    // old yvip landing page
+    "/en/v1/ch_YVIPModule1:MakeBeatsLearnCodePromoteEquity": "/en/v1/ch_YVIP_Intro.html",
 } as const


### PR DESCRIPTION
We renamed curriculum files at some point, and Amazon's landing page is still pointing to https://earsketch.gatech.edu/earsketch2/?curriculum=/en/v1/ch_YVIPModule1:MakeBeatsLearnCodePromoteEquity&language=python

This results in a **"Curriculum Failed to Load"** error and loads the curriculum homepage.

This points that old link to the new YVIP curriculum landing/intro page.