### PR TITLE
Check for null in parseKeySignature()

### DIFF
--- a/scripts/src/app/recommender.ts
+++ b/scripts/src/app/recommender.ts
@@ -291,6 +291,11 @@ export function availableInstruments() {
 }
 
 function parseKeySignature(filename: string) {
+    if (store.getState().sounds.defaultSounds.entities[filename] === undefined) {
+        // guard against mismatch of /audio/standard and sounds from json data files
+        soundKeyDict[filename] = { keySignature: undefined, relativeKey: undefined, keyConfidence: 0 }
+    }
+
     if (!Object.keys(soundKeyDict).includes(filename)) {
         const keyLabel = store.getState().sounds.defaultSounds.entities[filename].keySignature
         const keyNumber = keyLabel ? keyLabelToNumber(keyLabel) : undefined


### PR DESCRIPTION
Cypress tests are failing when /audio/standard is missing entries from recommender's json data files. This change handles any payload from /audio/standard/.