### PR TITLE
Cypress: use `force: true` to avoid detachment error.

### DIFF
--- a/tests/e2e-cypress/integration/sound-browser.spec.js
+++ b/tests/e2e-cypress/integration/sound-browser.spec.js
@@ -108,7 +108,7 @@ describe("preview sound", () => {
         // verify sound exists in the sound browser
         cy.contains("div", "Add a New Sound").should("not.exist")
         cy.contains("div", "SOUND COLLECTION (2)")
-        cy.contains("div.truncate", usernameUpper).click()
+        cy.contains("div.truncate", usernameUpper).click({ force: true })
         cy.contains("div", soundConst)
     })
 })


### PR DESCRIPTION
This is probably not the Right Way to resolve this, but it works.
The alternatives are doing `.wait()`, messing with our React code, or using a much more complicated workaround to try to see if the DOM has "settled".
See https://github.com/cypress-io/cypress/issues/7306 for more details; apparently this issue is common enough that the Cypress team is [looking into how to mitigate it](https://github.com/cypress-io/cypress/issues/7306#issuecomment-1098106831).