### PR TITLE
Make `selectRandomFile` async.

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -24,7 +24,6 @@ export const API_FUNCTIONS = {
     replaceString: { async: false, mod: false, return: true },
     reverseList: { async: false, mod: false, return: true },
     reverseString: { async: false, mod: false, return: true },
-    selectRandomFile: { async: false, mod: false, return: true },
     shuffleList: { async: false, mod: false, return: true },
     shuffleString: { async: false, mod: false, return: true },
     // Both return a value and modify DAW data.
@@ -41,4 +40,5 @@ export const API_FUNCTIONS = {
     readInput: { async: true, mod: false, return: true },
     importImage: { async: true, mod: false, return: true },
     importFile: { async: true, mod: false, return: true },
+    selectRandomFile: { async: true, mod: false, return: true },
 }

--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -1026,21 +1026,14 @@ export function selectRandomFile(result: DAWData, folderSubstring: string = "") 
     ptCheckArgs("selectRandomFile", args, 0, 1)
     ptCheckType("folderSubstring", "string", folderSubstring)
 
-    let url = URL_DOMAIN + "/audio/random?folderSubstring=" + folderSubstring
-
+    let endpoint = `/audio/random?folderSubstring=${folderSubstring}`
     if (user.selectLoggedIn(store.getState())) {
-        url += "&username=" + user.selectUserName(store.getState())
+        endpoint += "&username=" + user.selectUserName(store.getState())
     }
 
-    const request = new XMLHttpRequest()
-    request.open("GET", url, false)
-    request.send(null)
-
-    if (request.status === 200) {
-        return (JSON.parse(request.responseText) as SoundEntity).name
-    } else {
-        throw new InternalError("Internal server error. " + request.responseText)
-    }
+    return request.get(endpoint)
+        .then((entity: SoundEntity) => entity.name)
+        .catch(() => { throw new InternalError("Internal server error.") })
 }
 
 // Shuffle a list.


### PR DESCRIPTION
`selectRandomFile` makes a request to the API and should be async.
Also, synchronous XMLHttpRequests are [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#synchronous_request), and this caused problems with Skulpt (perhaps through a weird interaction with yieldLimit? unclear).

Fixes GTCMT/earsketch#2929.