### PR TITLE
Webpack: Split chunks.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -121,6 +121,7 @@ module.exports = {
             cacheGroups: {
                 default: false,
             },
+            chunks: "all",
         },
     },
 }

--- a/webpack.serve.js
+++ b/webpack.serve.js
@@ -22,7 +22,7 @@ module.exports = env => {
         mode: "development", // For localhost with websocket-dev-server
         output: {
             path: __dirname,
-            filename: "dist/bundle.js", // HtmlWebpackPlugin demands this workaround.
+            filename: "dist/bundle.[contenthash].js", // HtmlWebpackPlugin demands this workaround.
             publicPath: "/", // webclient folder
         },
         target: "web",


### PR DESCRIPTION
Will hopefully resolve GTCMT/earsketch#2933 by ensuring that no individual file (to be compressed by CloudFront) exceeds 10 MB.