### PR TITLE
Ignore superfluous `licenseInfo` field from API.

### DIFF
--- a/src/browser/Scripts.tsx
+++ b/src/browser/Scripts.tsx
@@ -6,6 +6,7 @@ import AutoSizer from "react-virtualized-auto-sizer"
 import { usePopper } from "react-popper"
 
 import type { Script, ScriptType } from "common"
+import licenses from "../data/licenses"
 import type { RootState } from "../reducers"
 import * as scripts from "./scriptsState"
 import * as scriptsThunks from "./scriptsThunks"
@@ -222,6 +223,7 @@ const SingletonSharedScriptInfo = () => {
     const dispatch = useDispatch()
     const showSharedScriptInfo = useSelector(scripts.selectShowSharedScriptInfo)
     const script = useSelector(scripts.selectSharedInfoScript)
+    const license = script?.license_id && licenses[script.license_id - 1]
 
     const [popperElement, setPopperElement] = useState<HTMLDivElement|null>(null)
     const { styles, attributes, update } = usePopper(sharedInfoPanelVirtualRef, popperElement)
@@ -272,7 +274,7 @@ const SingletonSharedScriptInfo = () => {
                 />
                 <SharedScriptInfoItem
                     title={t("sharedScript.license")}
-                    body={script.licenseInfo}
+                    body={license ? `${license.name} - ${license.description}` : ""}
                 />
                 <SharedScriptInfoItem
                     title={t("lastModified")}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -6,7 +6,6 @@ export interface Script {
     username: string
     created: number | string
     modified: number | string
-    licenseInfo: string
     license_id?: number
     saved: boolean
     tooltipText: string

--- a/tests/cypress/integration/collaboration.spec.js
+++ b/tests/cypress/integration/collaboration.spec.js
@@ -17,11 +17,6 @@ describe("collaboration", () => {
                 description: "",
                 file_location: "",
                 id: -1,
-                licenseInfo: `CC BY - Creative Commons Attribution: 
-This license lets others distribute, remix, tweak, and build upon your work, 
-even commercially, as long as they credit you for the original creation. This 
-is the most accommodating of licenses offered. Recommended for maximum 
-dissemination and use of licensed materials.`,
                 license_id: 1,
                 modified: "2022-02-03 19:04:38.0",
                 run_status: 2,

--- a/tests/cypress/integration/script-share.spec.js
+++ b/tests/cypress/integration/script-share.spec.js
@@ -23,7 +23,6 @@ describe("shared script", () => {
         description: "",
         file_location: "",
         id: -1,
-        licenseInfo: "CC BY - Creative Commons Attribution: This license lets others distribute, remix, tweak, and build upon your work, even commercially, as long as they credit you for the original creation. This is the most accommodating of licenses offered. Recommended for maximum dissemination and use of licensed materials.",
         license_id: 1,
         modified: "2022-03-28 17:56:44.0",
         name: "mondays.py",


### PR DESCRIPTION
Fixes GTCMT/earsketch#2959.

Sister PR of GTCMT/earsketch-api#56.