### PR TITLE
Fix JS regex Worker leak + crash in Chromium.

### DIFF
--- a/src/app/runner.ts
+++ b/src/app/runner.ts
@@ -213,6 +213,9 @@ function createJsInterpreter(code: string) {
         throw e
     }
 
+    // Run regular expressions in main thread instead of in workers;
+    // see https://github.com/GTCMT/earsketch-webclient/pull/466.
+    interpreter.REGEXP_MODE = 1
     interpreter.globalScope.strict = true // always enable strict mode
     return interpreter
 }


### PR DESCRIPTION
Fixes GTCMT/earsketch#2979.

It turns out that the memory issue with our interesting user script had nothing to do with the script's general complexity, but was merely due to the use of an innocuous regex in a loop. Here's a (much) smaller script that reproduces the issue and quickly kills a Chrome tab:

```js
for (var i = 0; i < 1000; i++) {
    /\d/.test("5")
}
```

In JS-Interpreter, by default, regular expressions run in Web Workers. A new worker is created for each call to `.match()`, `.search()`, `.split()`, `.replace()`, `.exec()`, and `.test()`.
This is done to deal with pathological regular expressions which explode in complexity, such as `"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaab".match(/^(a|aa+)+a+$/)`. If these are run in the main thread, they block for a long time, and there's no way to interrupt the sandbox's execution; in a worker, the main thread can set a timeout and abort the operation if it's taking too long. See https://github.com/NeilFraser/JS-Interpreter/issues/152 for the discussion and fix.

This wouldn't be an issue in itself, except that Chrome apparently doesn't clean up the workers once they're finished. Thus, in the small script above, they accumulate. On my machine, the tab crashes at 234 worker threads. In Firefox (and apparently Safari), the workers get cleaned up almost immediately after each regex call, and thus there's no crash.

I'm going to report this issue upstream to JS-Interpreter; it looks like there's an easy fix to make Chrome clean up the workers, and this bug is easily demonstrable outside of EarSketch on the JS-Interpreter [demo page](https://neil.fraser.name/software/JS-Interpreter/).

In the meantime, we can just switch to `REGEXP_MODE = 1` (see modes [here](https://github.com/NeilFraser/JS-Interpreter/blob/036ffcd482eb2f1992ec555d54cb89ffffc3b286/interpreter.js#L281)), which will just run the regexes in the main thread. This resolves the crash in Chrome and makes regexes quicker. The downside is that the user can hang their tab by executing a pathological regex (and they won't be able to use the CANCEL button because the main thread is blocked), but a) it's exceedingly unlikely anyone would manage this by accident and b) this is already possible in Python, because Skulpt doesn't do the fancy mitigation that JS-Interpreter does. 