### PR TITLE
Use new curriculum script name format for import

### DIFF
--- a/src/ide/IDE.tsx
+++ b/src/ide/IDE.tsx
@@ -300,6 +300,8 @@ function importExample(sourceCode: string) {
     // remove unsupported characters
     let scriptName
     if (result && result[1]) {
+        // we allow the english alphabet and accented latin characters
+        // see https://stackoverflow.com/a/26900132
         scriptName = result[1].replace(/[^\wÀ-ÖØ-öø-ÿ_]/g, "")
     } else {
         scriptName = "curriculum"


### PR DESCRIPTION
Curriculum examples may now use a comment on the first line to specify the name, as the old script_name keyword has been phased out. The webclient now parses the comment on line 1, if it exists, on import.