### PR TITLE
Apply envelope to sliced clips to avoid clicks

### DIFF
--- a/src/app/player.ts
+++ b/src/app/player.ts
@@ -61,11 +61,9 @@ const nodesToDestroy: any[] = []
 const playClip = (clip: Clip, trackGain: GainNode, tempoMap: TempoMap, startTime: number, endTime: number, waStartTime: number, manualOffset: number) => {
     const clipStartTime = tempoMap.measureToTime(clip.measure)
     const clipEndTime = clipStartTime + clip.audio.duration
-
-    const clipSource = new AudioBufferSourceNode(context, { buffer: clip.audio })
-
     // the clip duration may be shorter than the buffer duration if the loop end is set before the clip end
     const clipDuration = clipEndTime > endTime ? endTime - clipStartTime : clipEndTime - clipStartTime
+    const clipSource = new AudioBufferSourceNode(context, { buffer: clip.audio })
 
     if (startTime >= clipEndTime) {
         // case: clip is in the past: skip the clip

--- a/src/app/postRun.ts
+++ b/src/app/postRun.ts
@@ -250,8 +250,7 @@ export function fixClips(result: DAWData, buffers: { [key: string]: AudioBuffer 
 }
 
 function applyEnvelope(buffer: AudioBuffer, startRamp: boolean, endRamp: boolean) {
-    // Apply a simple piecewise-linear envelope (ramp up, sustain, ramp down) to an audio buffer.
-    // Useful for avoiding clicks/pops after slicing a clip.
+    // Apply a simple piecewise-linear envelope (ramp up, sustain, ramp down) to an audio buffer to avoid clicks after slicing.
     // Ramp length is 10ms or half the clip length, whichever is shorter.
     const rampLength = Math.min(buffer.length / 2, Math.floor(0.01 * buffer.sampleRate))
     for (let c = 0; c < buffer.numberOfChannels; c++) {


### PR DESCRIPTION
Apply a 10ms (at most) envelope to the start and end of sliced clips to prevent clicks/pops due to transients.

Fixes GTCMT/earsketch#2999.

@manodrum's test script from the linked issue:
```python
from earsketch import *

setTempo(120)

#sounds
kick = OS_KICK01

#beats
kickString = "0---0---0---0---"
kickTest = "0+++++++++++++++"
kickQuarter = "0++-0++-0++-0+++"

#song
makeBeat(kick, 1, 1, kickString)

makeBeat(kick, 2, 1, kickQuarter)
```

My test script for `createAudioSlice()`:
```python
from earsketch import *

slice = createAudioSlice(OS_KICK01, 1.1, 1.2)
insertMedia(slice, 1, 1)
insertMedia(slice, 1, 1.5)
insertMedia(slice, 1, 2)
```