### PR TITLE
Improve handling of API functions in autocomplete

### DIFF
--- a/src/browser/API.tsx
+++ b/src/browser/API.tsx
@@ -141,18 +141,6 @@ const Details = ({ obj }: { obj: APIItem }) => {
                         : <pre className="p-2 bg-gray-100 dark:bg-gray-800 border border-gray-300 rounded-md"><Code source={t(obj.example.javascriptKey)} language="javascript" /></pre>}
                 </div>
             </div>
-
-            {obj.expert &&
-            <div>
-                <div>Expert Description:</div>
-                <div className="api-browser description">{obj.expert}</div>
-            </div>}
-
-            {obj.caveats &&
-            <div>
-                <div>Caveats:</div>
-                <div className="api-browser description">{obj.caveats}</div>
-            </div>}
         </div>
     )
 }

--- a/src/data/api_doc.ts
+++ b/src/data/api_doc.ts
@@ -18,8 +18,7 @@ interface Item {
         descriptionKey: string
     }
     language?: string
-    expert?: string
-    caveats?: string
+    deprecated?: boolean
 }
 
 export interface APIItem extends Item {
@@ -178,6 +177,7 @@ const rawDoc: { [key: string]: Item[] } = {
             pythonKey: "api:finish.example.python",
             javascriptKey: "api:finish.example.javascript",
         },
+        deprecated: true,
     }],
     fitMedia: [{
         descriptionKey: "api:fitMedia.description",
@@ -257,6 +257,7 @@ const rawDoc: { [key: string]: Item[] } = {
             pythonKey: "api:init.example.python",
             javascriptKey: "api:init.example.javascript",
         },
+        deprecated: true,
     }],
     insertMedia: [{
         descriptionKey: "api:insertMedia.description",

--- a/src/ide/Editor.tsx
+++ b/src/ide/Editor.tsx
@@ -113,13 +113,15 @@ function getTheme() {
 // Autocomplete
 const pythonFunctions = []
 const javascriptFunctions = []
-for (const entries of Object.values(ESApiDoc)) {
+for (const [name, entries] of Object.entries(ESApiDoc)) {
     for (const entry of entries) {
+        if (entry.deprecated) continue
+        const args = entry.signature.substring(name.length)
         if (!entry.language || entry.language === "python") {
-            pythonFunctions.push(snippetCompletion(entry.template, { label: entry.signature, type: "function", detail: "Function" }))
+            pythonFunctions.push(snippetCompletion(entry.template, { label: name, type: "function", detail: args }))
         }
         if (!entry.language || entry.language === "javascript") {
-            javascriptFunctions.push(snippetCompletion(entry.template, { label: entry.signature, type: "function", detail: "Function" }))
+            javascriptFunctions.push(snippetCompletion(entry.template, { label: name, type: "function", detail: args }))
         }
     }
 }


### PR DESCRIPTION
Instead of putting function signatures in the completion label (which is the text that is matched), put them in the detail. (Including the signature is important to disambiguate between overloaded API functions like `setEffect`.)

Also, omit deprecated functions (`init` and `finish`) from autocomplete, and remove some unused fields (and corresponding JSX) from `api_doc`.

Fixes GTCMT/earsketch#3022, which was caused by using `completeFromList` with labels that had non-word characters.