### PR TITLE
Ignore fleet config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,11 @@ css/earsketch/allstyles.css
 css/earsketch/theme_dark.css
 css/earsketch/theme_light.css
 
-# IntelliJ IDEA
+# IntelliJ IDEA & Fleet
 .idea/
 *.iml
 out/
+.fleet/
 
 # Binaries (non-text)
 *.zip


### PR DESCRIPTION
Fleet is a new lightweight editor and IDE from JetBrains. This just adds it's config directory to our `.gitignore` file.