### PR TITLE
Handle out-of-bounds line numbers in Skulpt errors

### DIFF
--- a/src/ide/Editor.tsx
+++ b/src/ide/Editor.tsx
@@ -323,8 +323,10 @@ export function pasteCode(code: string) {
 
 export function highlightError(err: any) {
     const language = ESUtils.parseLanguage(tabs.selectActiveTabScript(store.getState()).name)
-    const lineNumber = language === "python" ? err.traceback?.[0]?.lineno : err.lineNumber
+    let lineNumber = language === "python" ? err.traceback?.[0]?.lineno : err.lineNumber
     if (lineNumber !== undefined) {
+        // Skulpt reports a line number greater than the document length for EOF; clamp to valid range.
+        lineNumber = Math.min(lineNumber, view.state.doc.lines)
         const line = view.state.doc.line(lineNumber)
         view.dispatch(setDiagnostics(view.state, [{
             from: line.from,


### PR DESCRIPTION
Steps to reproduce:
1. Create a script with a missing close paren:
```python
from earsketch import *
fitMedia(DUBSTEP_PERCDRUM_002,1,1,3
```
2. Execute the script, observe `SyntaxError: There is an error with the syntax (or arrangement) of code, EOF in multi-line statement on line 3` in user console.
3. Fix the error by appending a `)` and attempt to re-run.

In current EarSketch, re-running will do nothing, giving the appearance of a persistent EOF-related syntax error. This is the likely explanation for user reports such as GTCMT/earsketch#3029. (Such issues are confusing because they show valid code paired with an apparent syntax error, but to trigger this bug, the user would have had to run a broken script _beforehand_, putting the app in a bad state.)

The source of this bug is Skulpt reporting line numbers that are greater than the document length in the case of unexpected EOF (e.g. expected `)` but reached the end of the script without seeing it) plus our trying to highlighting the line with the error. (CodeMirror reasonably throws an exception if you ask for a line that doesn't exist.)

This PR fixes the issue by capping the line number before highlighting, so we highlight the last line in case of unexpected EOF.

For what it's worth, I don't think this qualifies as a bug in Skulpt; it's accurately reflecting Python 2 error reporting, whereas modern Python (at least as of 3.10) has more helpful messages & line numbers:
```bash
$ cat > tmp.py
print(5
$ python2 tmp.py 
  File "tmp.py", line 2
    
           ^
SyntaxError: invalid syntax
$ python3 tmp.py 
  File "/home/ian/tmp.py", line 1
    print(5
         ^
SyntaxError: '(' was never closed
```

Closes GTCMT/earsketch#3029, GTCMT/earsketch#3088, GTCMT/earsketch#3106, GTCMT/earsketch#3108.