### PR TITLE
Remove requests for info in the script template

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1108,8 +1108,8 @@
     }
   },
   "templates": {
-    "python": "# <your title here>: <your description here>\nfrom earsketch import *\n\nsetTempo(120)\n",
-    "javascript": "// <your title here>: <your description here>\nsetTempo(120);\n"
+    "python": "# description: \nfrom earsketch import *\n\nsetTempo(120)\n",
+    "javascript": "// description: \nsetTempo(120);\n"
   },
   "console": {
     "warningHeading": "Warning message",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -807,7 +807,7 @@
     }
   },
   "templates": {
-    "python": "# <tu titulo aquí>: <tu descripción aquí>\n\nfrom earsketch import *\n\nsetTempo(120)\n",
-    "javascript": "// <tu titulo aquí>: <tu descripción aquí>\n\nsetTempo(120);\n"
+    "python": "# descripción: \nfrom earsketch import *\n\nsetTempo(120)\n",
+    "javascript": "// descripción: \nsetTempo(120);\n"
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -819,7 +819,7 @@
     }
   },
   "templates": {
-    "python": "<votre titre ici> : <votre descriptif ici>\nfrom earsketch import *\n\nsetTempo(120)\n",
-    "javascript": "<votre titre ici> : <votre descriptif ici>\n\nsetTempo(120);\n"
+    "python": "# description : \nfrom earsketch import *\n\nsetTempo(120)\n",
+    "javascript": "// description : \n\nsetTempo(120);\n"
   }
 }

--- a/src/locales/iu/common.json
+++ b/src/locales/iu/common.json
@@ -848,7 +848,7 @@
     }
   },
   "templates": {
-    "python": "# <your title here>: <your description here>\nfrom earsketch import *\n\nsetTempo(120)\n",
-    "javascript": "// <your title here>: <your description here>\nsetTempo(120);\n"
+    "python": "# description: \nfrom earsketch import *\n\nsetTempo(120)\n",
+    "javascript": "// description: \nsetTempo(120);\n"
   }
 }

--- a/src/locales/oj/common.json
+++ b/src/locales/oj/common.json
@@ -848,7 +848,7 @@
     }
   },
   "templates": {
-    "python": "# <your title here>: <your description here>\nfrom earsketch import *\n\nsetTempo(120)\n",
-    "javascript": "// <your title here>: <your description here>\nsetTempo(120);\n"
+    "python": "# description: \nfrom earsketch import *\n\nsetTempo(120)\n",
+    "javascript": "// description: \nsetTempo(120);\n"
   }
 }


### PR DESCRIPTION
To support student privacy, we are removing prompts for personal information in the comment block.