### PR TITLE
Remove editor widgets from screenreaders

### DIFF
--- a/src/ide/EditorWidgets.ts
+++ b/src/ide/EditorWidgets.ts
@@ -21,7 +21,9 @@ class SoundPreviewWidget extends WidgetType {
     toDOM() {
         const wrap = document.createElement("span")
         wrap.className = "cm-preview-sound ml-1.5"
+        wrap.setAttribute("aria-hidden", "true")
         const previewButton = wrap.appendChild(document.createElement("button"))
+        previewButton.setAttribute("tabindex", "-1")
         previewButton.value = this.name
         previewButton.innerHTML = {
             playing: '<i class="icon icon-stop2" />',


### PR DESCRIPTION
remove the wrapping span from the accessibility tree, and make the preview button non-focusable

Otherwise this causes issues as screenreader users try to escape and tab out of the editor