### PR TITLE
Ensure automation point at beginning takes effect

### DIFF
--- a/src/audio/effects.ts
+++ b/src/audio/effects.ts
@@ -75,7 +75,7 @@ export function buildEffectGraph(
         let lastShape = "square"
         for (const [pointIndex, point] of envelope.entries()) {
             // TODO: Interpolate based on current time in case we're in the middle of a ramp.
-            const pastEndLocation = (pointIndex < envelope.length - 1) && (tempoMap.measureToTime(point.measure) <= offsetInSeconds)
+            const pastEndLocation = (pointIndex < envelope.length - 1) && (tempoMap.measureToTime(point.measure) < offsetInSeconds)
             let time = Math.max(context.currentTime + tempoMap.measureToTime(point.measure) - offsetInSeconds, context.currentTime)
             // Scale values from the ranges the user passes into the API to the ranges our Web Audio nodes expect.
             const value = EffectType.scale(parameter, point.value)


### PR DESCRIPTION
Runoff from #562.

Test:
```python
from earsketch import *
fitMedia(RD_POP_SYNTHBASS_6, 1, 1, 5)
setEffect(1, VOLUME,GAIN, -20, 2, 6, 5)
```

Without this change, volume drops abruptly at measure 2 (contrary to the graph in the DAW). With this change, volume is initially -20 dB, as expected.

(This one-character change only matters because we still don't interpolate between automation points when the user seeks - a long-standing issue which we should fix soon, in a slightly larger PR.)