### PR TITLE
Allow embedded links in broadcast notifications

### DIFF
--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -266,7 +266,7 @@ const MarkdownLinkMessage = ({ text }: { text: string }): JSX.Element => {
         } else if (index % 3 === 2) {
             const linkText = parts[index - 1]
             const linkUrl = parts[index]
-            return <a href={linkUrl} target="_blank" rel="noopener noreferrer" key={index}>{linkText}</a>
+            return <a href={linkUrl} target="_blank" rel="noreferrer" key={index}>{linkText}</a>
         } else {
             return null
         }


### PR DESCRIPTION
This feature allows markdown-style links within broadcast message text.

For example:
`Check out [EarSketch](https://earsketch.gatech.edu), a project from [Georgia Tech](https://www.gatech.edu).`

Addresses GTCMT/earsketch#3201.