### PR TITLE
Use "tempo" to avoid confusion in setTempo() range errors

### DIFF
--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -61,9 +61,8 @@ export function setTempo(result: DAWData, startTempo: number, startMeasure?: num
 
     const args = [...arguments].slice(1) // remove first argument
     ptCheckArgs("setTempo", args, 1, 4)
-
-    ptCheckType(startMeasure === undefined ? "tempo" : "startTempo", "number", startTempo)
-    ptCheckRange(startMeasure === undefined ? "tempo" : "startTempo", startTempo, 45, 220)
+    ptCheckType(args.length > 1 ? "startTempo" : "tempo", "number", startTempo)
+    ptCheckRange(args.length > 1 ? "startTempo" : "tempo", startTempo, 45, 220)
 
     if (startMeasure === undefined) {
         startMeasure = 1


### PR DESCRIPTION
This addresses confusion for users with `setTempo(tempo)`.

Today: "TypeError: There is an error with ... **startTempo** ... range of 45 to 220 on line 2"
New: "TypeError: There is an error with ... **tempo** ... range of 45 to 220 on line 2 "

For the long form `setTempo(startTempo, start, endTempo, end)`, the error message remains unchanged.
 
Resolves GTCMT/earsketch#3192