### PR TITLE
Report collaboration errors

### DIFF
--- a/src/app/collaboration.ts
+++ b/src/app/collaboration.ts
@@ -198,6 +198,7 @@ function onSessionStatus(data: Message) {
 
 function onFailedToSynchronize() {
     userNotification.show("Failed to synchronize with the central server. You might already have another EarSketch window or tab open somewhere. To fix  please refresh page.", "failure2", 999)
+    reporter.failedToSync()
 }
 
 function joinSession(shareID: string, username_: string) {
@@ -259,6 +260,7 @@ function onSessionsFull(data: Message) {
     delete timeouts[userName]
     esconsole("could not create a session. max number reached: " + data.scriptID, "collab")
     userNotification.show("Server has reached the maximum number of real-time collaboration sessions. Please try again later.", "failure1")
+    reporter.collabServerFull()
     openScriptOffline(script!)
 }
 
@@ -497,6 +499,7 @@ function syncToSession(data: Message) {
 
 function onSyncError(data: Message) {
     userNotification.showBanner("There was a sync error. Adjusting the local edit...")
+    reporter.syncError()
     syncToSession(data)
 }
 
@@ -512,6 +515,7 @@ function onSyncToSession(data: Message) {
 function rejoinSession() {
     if (active) {
         userNotification.showBanner("Synchronization error: Rejoining the session", "failure1")
+        reporter.syncErrorRejoin()
 
         initialize()
 
@@ -605,6 +609,7 @@ function onSessionClosed() {
 
 function onSessionClosedForInactivity() {
     userNotification.show("Remote collaboration session was closed because of a prolonged inactivitiy.")
+    reporter.inactiveSessionClosed()
 }
 
 function beforeTransf(operation: EditOperation) {

--- a/src/app/reporter.ts
+++ b/src/app/reporter.ts
@@ -5,6 +5,7 @@ import { Language } from "common"
 const ACTIONS = {
     user: ["login", "logout", "openHistory", "sidebarTogglesClicked", "toggleColorTheme"],
     script: ["createScript", "deleteScript", "openScript", "openSharedScript", "renameScript", "renameSharedScript", "revertScript", "saveScript", "saveSharedScript"],
+    collab: ["syncError", "syncErrorRejoin", "failedToSync", "collabServerFull", "inactiveSessionClosed"],
 }
 
 const module: { [key: string]: Function } = {}


### PR DESCRIPTION
This will instrument and report as google analytics events any collaboration errors (sync errors, failures to sync, collab server sessions full, inactive sessions ending).