### PR TITLE
Don't cache rejected promises when fetching sounds

### DIFF
--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -8,14 +8,17 @@ export type Sound = SoundEntity & { buffer: AudioBuffer }
 export const cache = {
     // We cache promises (rather than results) so we don't launch a second request while waiting on the first request.
     standardSounds: null as Promise<{ sounds: SoundEntity[], folders: string[] }> | null,
-    promises: Object.create(null) as { [key: string]: Promise<Sound> },
+    promises: Object.create(null) as { [key: string]: Promise<Sound> | undefined },
 }
 
 // Get an audio buffer from a file key.
 //   filekey: The constant associated with the audio clip that users type in EarSketch code.
 //   tempo: Tempo to scale the returned clip to.
 export function getSound(filekey: string) {
-    return cache.promises[filekey] ?? (cache.promises[filekey] = _getSound(filekey))
+    let promise = cache.promises[filekey]
+    if (promise) return promise
+    promise = _getSound(filekey)
+    return promise.then(sound => { cache.promises[filekey] = promise; return sound })
 }
 
 async function _getSound(name: string) {


### PR DESCRIPTION
Test procedure:
- Insert code to simulate brief loss of connectivity:
```ts
Object.assign(window as any, {
    testFetch: fetch,
    breakFetch() {
        (window as any).testFetch = async (...args: any[]) => { console.log(args); throw new Error("fail") }
    },
    restoreFetch() {
        (window as any).testFetch = window.fetch
    },
})

// and replace the call to `fetch()` in `_getSound()` with a call to `testFetch()`
```
- Call `breakFetch()` and run a script that inserts at least one sound; observe error.
- Call `restoreFetch()` and run the script again.

Before PR: run fails even after `restoreFetch()` due to rejected promise getting cached.
After PR: run succeeds after `restoreFetch()`.

Addresses GTCMT/earsketch#3257.