### PR TITLE
Autograder Updates Spring 2024

### DIFF
--- a/src/app/Autograder.tsx
+++ b/src/app/Autograder.tsx
@@ -115,12 +115,11 @@ const compare = (reference: DAWData, test: DAWData, testAllTracks: boolean, test
         test.tracks = grep(test.tracks, (n: any, i: number) => testTracks[i])
     }
     // remove sourceLine property
-    reference.tracks.forEach((_, i: number) => {
-        reference.tracks[i].clips.forEach((clip) => { clip.sourceLine = 0 })
-    })
-    test.tracks.forEach((_, i: number) => {
-        test.tracks[i].clips.forEach((clip) => { clip.sourceLine = 0 })
-    })
+    for (const track of reference.tracks.concat(test.tracks)) {
+        for (const clip of track.clips) {
+            clip.sourceLine = 0
+        }
+    }
     return JSON.stringify(reference) === JSON.stringify(test)
 }
 


### PR DESCRIPTION
In compliance with recent changes to React and EarSketch:

- `sourceLine` comparison: we remove the `sourceLine` field (used for DAW -> Editor highlighting) when comparing reference files to test files, since this was causing identical outputs to fail based on spacing differences.
- `useEffect` cleanup: Because useEffect applies twice, we now destroy CodeMirror contents to clean up the `CodeEmbed` object. We do this with `container`, a local copy of `editorContainer.current`.
- `results` mutation: we now copy the `results` object locally, so that the `TestResults` updates correctly instead of "freezing".