### PR TITLE
Add headless ui modal guard to cypress  Editor tests

### DIFF
--- a/tests/cypress/e2e/editor.cy.js
+++ b/tests/cypress/e2e/editor.cy.js
@@ -17,8 +17,7 @@ describe("Editor", () => {
         cy.get('[data-test="newScript"]').click()
         cy.get("#scriptName").type("cypress_test")
         cy.get("input").contains("CREATE").click()
-        cy.contains("div", "Create a new script", { timeout: 10000 }).should("not.exist")
-        cy.get("div[id^='headlessui-dialog-']", { timeout: 10000 }).should("not.exist")
+        cy.waitForHeadlessDialog()
     })
 
     it("runs template script", () => {
@@ -91,6 +90,7 @@ print(5 % 2)
         cy.get("select[title='Switch script language']").select("JavaScript")
         cy.get("#scriptName").type("js_test")
         cy.get("input").contains("CREATE").click()
+        cy.waitForHeadlessDialog()
 
         // Enter new text with fitMedia()
         cy.get("#editor").type(`{selectAll}{del}{enter}

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -41,6 +41,15 @@ Cypress.Commands.add("incomingWebSocketMessage", (wsServer, message) => {
 })
 
 /**
+ * @memberof cy
+ * @method waitForHeadlessDialog
+ * @returns Chainable
+ */
+Cypress.Commands.add("waitForHeadlessDialog", () => {
+    cy.get("div[id^='headlessui-dialog-']", { timeout: 10000 }).should("not.exist")
+})
+
+/**
  * @memberOf cy
  * @method skipTour
  * @returns Chainable
@@ -49,7 +58,7 @@ Cypress.Commands.add("skipTour", () => {
     cy.get("body").find("button").contains("Skip").click()
     // wait for the quick tour modal to disappear
     cy.contains("h2", "Quick tour page 0 out of 10", { timeout: 10000 }).should("not.exist")
-    cy.get("div[id^='headlessui-dialog-']", { timeout: 10000 }).should("not.exist")
+    cy.waitForHeadlessDialog()
 })
 
 /**


### PR DESCRIPTION
wait for all headless modal divs to go away, including overlays and modal window