### PR TITLE
Don't persist `app.modal` in Redux state

### DIFF
--- a/src/app/appState.ts
+++ b/src/app/appState.ts
@@ -74,7 +74,7 @@ const appSlice = createSlice({
 
 const persistConfig = {
     key: "app",
-    blacklist: ["embedMode", "hideDAW", "hideEditor", "embeddedScriptUsername", "embeddedScriptName", "embeddedShareID", "confetti"],
+    blacklist: ["embedMode", "hideDAW", "hideEditor", "embeddedScriptUsername", "embeddedScriptName", "embeddedShareID", "modal", "confetti"],
     storage,
 }
 


### PR DESCRIPTION
Fixes GTCMT/earsketch#3328