### PR TITLE
Fade out on render to allow audio effect tails

### DIFF
--- a/src/audio/effectlibrary.ts
+++ b/src/audio/effectlibrary.ts
@@ -144,7 +144,7 @@ export class DelayEffect extends MixableEffect {
     static override DEFAULT_PARAM = "DELAY_TIME"
     static override PARAMETERS = {
         DELAY_TIME: { min: 0.0, max: 4000.0, default: 300, scale: millisecondsToSeconds },
-        DELAY_FEEDBACK: { min: -120.0, max: -1.0, default: -5.0, scale: dbToFloat },
+        DELAY_FEEDBACK: { min: -120.0, max: -0.0, default: -5.0, scale: dbToFloat },
         ...super.PARAMETERS,
         MIX: { ...super.PARAMETERS.MIX, default: 0.5 },
     }

--- a/src/audio/effectlibrary.ts
+++ b/src/audio/effectlibrary.ts
@@ -144,7 +144,7 @@ export class DelayEffect extends MixableEffect {
     static override DEFAULT_PARAM = "DELAY_TIME"
     static override PARAMETERS = {
         DELAY_TIME: { min: 0.0, max: 4000.0, default: 300, scale: millisecondsToSeconds },
-        DELAY_FEEDBACK: { min: -120.0, max: -0.0, default: -5.0, scale: dbToFloat },
+        DELAY_FEEDBACK: { min: -120.0, max: -1.0, default: -5.0, scale: dbToFloat },
         ...super.PARAMETERS,
         MIX: { ...super.PARAMETERS.MIX, default: 0.5 },
     }

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -17,10 +17,12 @@ const SAMPLE_RATE = 44100
 // Render a result for offline playback.
 export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
-
     const tempoMap = new TempoMap(dawData)
+
     const fadeOutDuration = 0.4
-    const duration = tempoMap.measureToTime(dawData.length + 1) + fadeOutDuration // need +1 to render to end of last measure
+    const songDuration = tempoMap.measureToTime(dawData.length + 1) // need +1 to render to end of last measure
+    const duration = songDuration + fadeOutDuration
+
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
 
@@ -40,7 +42,7 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    out.gain.setValueAtTime(1, duration - fadeOutDuration)
+    out.gain.setValueAtTime(1, songDuration)
     out.gain.linearRampToValueAtTime(0, duration)
 
     const buffer = await context.startRendering()

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -23,14 +23,13 @@ export async function renderBuffer(dawData: DAWData) {
     const duration = tempoMap.measureToTime(dawData.length + 1) + fadeOutDuration // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
+
     const out = new GainNode(context)
     out.connect(context.destination)
     const projectGraph: ProjectGraph = {
         tracks: [],
         mix: new GainNode(context),
     }
-
-    const fadeOutStartTime = duration - fadeOutDuration
 
     // NOTE: When rendering projects, we ignore solo/mute/bypass.
     for (const [i, track] of dawData.tracks.entries()) {
@@ -41,7 +40,7 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    out.gain.setValueAtTime(1, fadeOutStartTime)
+    out.gain.setValueAtTime(1, duration - fadeOutDuration)
     out.gain.linearRampToValueAtTime(0.1, duration)
     out.gain.setValueAtTime(0, duration)
 

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,8 +19,8 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const endOfSongPadding = 1
-    const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
+    const fadeOutDuration = 0.4
+    const duration = tempoMap.measureToTime(dawData.length + 1) + fadeOutDuration // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
     const out = new GainNode(context)
@@ -30,6 +30,8 @@ export async function renderBuffer(dawData: DAWData) {
         mix: new GainNode(context),
     }
 
+    const fadeOutStartTime = duration - fadeOutDuration
+
     // NOTE: When rendering projects, we ignore solo/mute/bypass.
     for (const [i, track] of dawData.tracks.entries()) {
         const trackGraph = playTrack(context, i, track, out, tempoMap, 0, duration, context.currentTime, projectGraph.mix, [], true)
@@ -38,9 +40,6 @@ export async function renderBuffer(dawData: DAWData) {
             trackGraph.output.gain.value = 0 // mute metronome
         }
     }
-
-    const fadeOutDuration = 0.4
-    const fadeOutStartTime = duration - fadeOutDuration
 
     out.gain.setValueAtTime(1, fadeOutStartTime)
     out.gain.linearRampToValueAtTime(0.1, duration)

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,7 +19,8 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const duration = tempoMap.measureToTime(dawData.length + 1) // need +1 to render to end of last measure
+    const endOfSongPadding = 3
+    const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
 

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -39,7 +39,7 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    const fadeOutDuration = 0.3; 
+    const fadeOutDuration = 0.5; 
     const fadeOutStartTime = duration - fadeOutDuration;
 
     out.gain.setValueAtTime(1, fadeOutStartTime);

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -42,9 +42,9 @@ export async function renderBuffer(dawData: DAWData) {
     const fadeOutDuration = 0.4
     const fadeOutStartTime = duration - fadeOutDuration
 
-    out.gain.setValueAtTime(1, fadeOutStartTime);
-    out.gain.linearRampToValueAtTime(0.1, duration);
-    out.gain.setValueAtTime(0, duration);
+    out.gain.setValueAtTime(1, fadeOutStartTime)
+    out.gain.linearRampToValueAtTime(0.1, duration)
+    out.gain.setValueAtTime(0, duration)
 
     const buffer = await context.startRendering()
     esconsole("Render to buffer completed.", ["debug", "renderer"])

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,7 +19,7 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const endOfSongPadding = 3
+    const endOfSongPadding = 1 // + 1 
     const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
@@ -39,11 +39,12 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    const fadeOutDuration = 0.5; 
+    const fadeOutDuration = 0.4; 
     const fadeOutStartTime = duration - fadeOutDuration;
 
     out.gain.setValueAtTime(1, fadeOutStartTime);
-    out.gain.linearRampToValueAtTime(0, duration); 
+    out.gain.linearRampToValueAtTime(0.001, duration); //testing 
+    out.gain.setValueAtTime(0, duration); 
 
     const buffer = await context.startRendering()
     esconsole("Render to buffer completed.", ["debug", "renderer"])

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -23,7 +23,6 @@ export async function renderBuffer(dawData: DAWData) {
     const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
-
     const out = new GainNode(context)
     out.connect(context.destination)
     const projectGraph: ProjectGraph = {
@@ -39,6 +38,12 @@ export async function renderBuffer(dawData: DAWData) {
             trackGraph.output.gain.value = 0 // mute metronome
         }
     }
+
+    const fadeOutDuration = 0.3; 
+    const fadeOutStartTime = duration - fadeOutDuration;
+
+    out.gain.setValueAtTime(1, fadeOutStartTime);
+    out.gain.linearRampToValueAtTime(0, duration); 
 
     const buffer = await context.startRendering()
     esconsole("Render to buffer completed.", ["debug", "renderer"])

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -43,7 +43,7 @@ export async function renderBuffer(dawData: DAWData) {
     const fadeOutStartTime = duration - fadeOutDuration;
 
     out.gain.setValueAtTime(1, fadeOutStartTime);
-    out.gain.linearRampToValueAtTime(0.001, duration); //testing 
+    out.gain.linearRampToValueAtTime(0.1, duration); 
     out.gain.setValueAtTime(0, duration); 
 
     const buffer = await context.startRendering()

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -41,8 +41,7 @@ export async function renderBuffer(dawData: DAWData) {
     }
 
     out.gain.setValueAtTime(1, duration - fadeOutDuration)
-    out.gain.linearRampToValueAtTime(0.1, duration)
-    out.gain.setValueAtTime(0, duration)
+    out.gain.linearRampToValueAtTime(0, duration)
 
     const buffer = await context.startRendering()
     esconsole("Render to buffer completed.", ["debug", "renderer"])

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,7 +19,7 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const endOfSongPadding = 1; // 
+    const endOfSongPadding = 1 //
     const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
@@ -39,12 +39,12 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    const fadeOutDuration = 0.4; 
+    const fadeOutDuration = 0.4;
     const fadeOutStartTime = duration - fadeOutDuration;
 
     out.gain.setValueAtTime(1, fadeOutStartTime);
-    out.gain.linearRampToValueAtTime(0.1, duration); 
-    out.gain.setValueAtTime(0, duration); 
+    out.gain.linearRampToValueAtTime(0.1, duration);
+    out.gain.setValueAtTime(0, duration);
 
     const buffer = await context.startRendering()
     esconsole("Render to buffer completed.", ["debug", "renderer"])

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -39,7 +39,7 @@ export async function renderBuffer(dawData: DAWData) {
         }
     }
 
-    const fadeOutDuration = 0.4;
+    const fadeOutDuration = 0.4
     const fadeOutStartTime = duration - fadeOutDuration;
 
     out.gain.setValueAtTime(1, fadeOutStartTime);

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,7 +19,7 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const endOfSongPadding = 1 // + 1 
+    const endOfSongPadding = 1; // 
     const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)

--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -19,7 +19,7 @@ export async function renderBuffer(dawData: DAWData) {
     esconsole("Begin rendering result to buffer.", ["debug", "renderer"])
 
     const tempoMap = new TempoMap(dawData)
-    const endOfSongPadding = 1 //
+    const endOfSongPadding = 1
     const duration = tempoMap.measureToTime(dawData.length + 1) + endOfSongPadding // need +1 to render to end of last measure
     const context = new OfflineAudioContext(NUM_CHANNELS, SAMPLE_RATE * duration, SAMPLE_RATE)
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
@@ -40,7 +40,7 @@ export async function renderBuffer(dawData: DAWData) {
     }
 
     const fadeOutDuration = 0.4
-    const fadeOutStartTime = duration - fadeOutDuration;
+    const fadeOutStartTime = duration - fadeOutDuration
 
     out.gain.setValueAtTime(1, fadeOutStartTime);
     out.gain.linearRampToValueAtTime(0.1, duration);


### PR DESCRIPTION
For rendering to wav/mp3, extended the song by 1 second with a linear ramp fade out, to allow audio effect tails.