### PR TITLE
UI Bug Fix: Numeric badges on top of sound filter buttons

### DIFF
--- a/src/browser/Sounds.tsx
+++ b/src/browser/Sounds.tsx
@@ -477,7 +477,7 @@ const SoundFilters = ({ currentFilterTab, setCurrentFilterTab, setFilterHeight }
                 <ShowOnlyFavorites />
                 <AddSound />
             </div>
-            <div className="flex justify-between items-end px-1.5 py-1 mb-0.5">
+            <div className="flex justify-between items-end px-1.5 py-1 mb-2">
                 <button
                     className={clearClassnames}
                     onClick={() => { dispatch(sounds.resetAllFilters()); reloadRecommendations() }}


### PR DESCRIPTION
Increase margin to make room for top of badges. Top of badges were getting cut off due to relocation of sound search box.