### PR TITLE
Load beat timestamp data lazily

### DIFF
--- a/src/cai/analysis/creativityAssessment.ts
+++ b/src/cai/analysis/creativityAssessment.ts
@@ -8,13 +8,6 @@ import { getTimestampData } from "../../data/recommendationData"
 import { Results } from "../complexityCalculator"
 import { combinations, entropy, hammingDistance, normalize } from "./utils"
 
-type beatTimestampData = {
-    beat_timestamps: number[],
-    duration: number
-}
-
-const beatTimestampsPromise: Promise<{ [key: string]: beatTimestampData }> = getTimestampData()
-
 export interface CaiHistoryNode {
     created: string,
     username: string,
@@ -138,9 +131,9 @@ export async function assess(complexity: Results, analysisReport: Report, timeOn
     // map BEAT_TIMESTAMPS to soundFeatures
     for (const sound of uniqueSounds) {
         // const beatTrack = [sound].beat_timestamps
-        const soundData = (await beatTimestampsPromise)[sound]
+        const soundData = (await getTimestampData())[sound]
         if (soundData) {
-            const beatTrack = (await beatTimestampsPromise)[sound].beat_timestamps
+            const beatTrack = soundData.beat_timestamps
             soundFeatures.push({ name: sound, beat_track: beatTrack })
         }
     }

--- a/src/data/recommendationData.ts
+++ b/src/data/recommendationData.ts
@@ -10,6 +10,15 @@ export async function getBeatData() {
     return (await fetch(beatDataURL)).json()
 }
 
+type BeatTimestampData = {
+    beat_timestamps: number[],
+    duration: number
+}
+
+let timestampDataPromise: Promise<{ [key: string]: BeatTimestampData }>
 export async function getTimestampData() {
-    return (await fetch(beatTimestampsURL)).json()
+    if (timestampDataPromise) {
+        return await timestampDataPromise
+    }
+    return (timestampDataPromise = fetch(beatTimestampsURL).then(r => r.json()))
 }


### PR DESCRIPTION
No need to load the beat timestamp JSON data in the main app, as it's only used by CodeAnalyzer.