### PR TITLE
Handle all dates as iso 8601 strings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -218,7 +218,6 @@ async function refreshCodeBrowser() {
 
         const scripts: { [key: string]: Script } = {}
         for (const script of fetchedScripts) {
-            script.modified = ESUtils.parseDate(script.modified as string)
             // set this flag to false when the script gets modified
             // then set it to true when the script gets saved
             script.saved = true

--- a/src/app/ScriptHistory.tsx
+++ b/src/app/ScriptHistory.tsx
@@ -20,8 +20,8 @@ function parseActiveUsers(activeUsers: string | string[]) {
     return Array.isArray(activeUsers) ? activeUsers.join(", ") : activeUsers
 }
 
-const Version = ({ version, now, allowRevert, compiled, active, activate, run, revert, closeDAW }: {
-    version: any, now: number, allowRevert: boolean, compiled: boolean, active: boolean, run: any, activate: any, revert: any, closeDAW: any
+const Version = ({ version, allowRevert, compiled, active, activate, run, revert, closeDAW }: {
+    version: any, allowRevert: boolean, compiled: boolean, active: boolean, run: any, activate: any, revert: any, closeDAW: any
 }) => {
     const { t } = useTranslation()
     return <tr className={`border-t border-gray-200 ${active ? "bg-gray-100 dark:bg-gray-800" : ""}`}>
@@ -34,7 +34,7 @@ const Version = ({ version, now, allowRevert, compiled, active, activate, run, r
         <td className="pl-2.5 py-1.5 text-sm" onClick={activate}>
             {`${t("version")} ${version.id}`}
             {version.activeUsers && <span><i className="icon-users" style={{ color: "#6dfed4" }}></i></span>}
-            <div className="mt-1 text-gray-500">{ESUtils.formatTime(now - version.created)}</div>
+            <div className="mt-1 text-gray-500">{ESUtils.humanReadableTimeAgo(version.created)}</div>
         </td>
         {allowRevert && <td className="pl-2.5"><button onClick={revert} title={t("scriptHistory.restore")}>
             <i className="icon-rotate-cw2 inline-block text-blue-500" style={{ transform: "scaleX(-1)" }}></i>
@@ -64,7 +64,6 @@ export const ScriptHistory = ({ script, allowRevert, close }: { script: Script, 
     // Chronologically adjacent versions of the script for the diff.
     const original = history?.[active + 1]
     const modified = history?.[active]
-    const now = Date.now()
     const { t } = useTranslation()
 
     useEffect(() => {
@@ -128,7 +127,7 @@ export const ScriptHistory = ({ script, allowRevert, close }: { script: Script, 
                                 <tbody>
                                     {history.map((version, index) =>
                                         <Version
-                                            key={version.id} version={version} now={now} active={active === index}
+                                            key={version.id} version={version} active={active === index}
                                             allowRevert={allowRevert} compiled={compiledResult !== null}
                                             activate={() => {
                                                 setActive(index)

--- a/src/browser/scriptsThunks.ts
+++ b/src/browser/scriptsThunks.ts
@@ -4,7 +4,7 @@ import i18n from "i18next"
 import type { Script } from "common"
 import * as collaboration from "../app/collaboration"
 import esconsole from "../esconsole"
-import { fromEntries, parseDate } from "../esutils"
+import { fromEntries } from "../esutils"
 import type { ThunkAPI } from "../reducers"
 import { get, getAuth, postAuth } from "../request"
 import {
@@ -263,9 +263,6 @@ export async function getLockedSharedScriptId(shareid: string) {
 export async function getScriptHistory(scriptid: string) {
     esconsole("Getting script history: " + scriptid, ["debug", "user"])
     const scripts: Script[] = await getAuth("/scripts/history", { scriptid })
-    for (const script of scripts) {
-        script.created = parseDate(script.created as string)
-    }
     return scripts
 }
 

--- a/src/cai/CAI.tsx
+++ b/src/cai/CAI.tsx
@@ -110,7 +110,7 @@ const CaiMessageView = ({ message }: { message: cai.CaiMessage }) => {
                 textAlign: message.sender === userName ? "right" : "left",
                 width: "80%",
             }}>
-                {ESUtils.formatTime(Date.now() - message.date)}
+                {ESUtils.humanReadableTimeAgo(message.date)}
             </div>
         </div>
     )

--- a/src/esutils.ts
+++ b/src/esutils.ts
@@ -50,14 +50,6 @@ export const parseExt = (filename: string) => {
     return match ? match[0] : ""
 }
 
-// Change our custom (?) date format into ISO 8601, then parse.
-// TODO: Dates should be stored in a standard format in the database so as to make this unnecessary.
-export function parseDate(date: string) {
-    // Change created date to ISO 8601
-    const isoFormat = date.slice(0, -2).replace(" ", "T")
-    return Date.parse(isoFormat)
-}
-
 export const isMobileBrowser = () => {
     const a = window.navigator.userAgent || window.navigator.vendor || (window as any).opera
     return (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(a.substr(0, 4)))
@@ -156,9 +148,18 @@ export const checkIllegalCharacters = (input: string) => {
     return input.match(matchPattern)
 }
 
-// Converts a time difference to a description of how much time has passed.
-export const formatTime = (milliseconds: number) => {
-    const seconds = Math.floor(milliseconds / 1000)
+/**
+ * Returns a human-readable description of how long ago the given date was.
+ * Supports dates in ISO 8601 format, timestamps, and Date objects.
+ * @example
+ * humanReadableTimeAgo("2024-01-01T00:00:00.000Z") // "1 year ago"
+ * humanReadableTimeAgo(1612147200000) // "1 year ago"
+ */
+export const humanReadableTimeAgo = (date: string | number | Date) => {
+    const then = new Date(date)
+    const diff = Date.now() - then.getTime()
+
+    const seconds = Math.floor(diff / 1000)
     const minutes = Math.floor(seconds / 60)
     const hours = Math.floor(minutes / 60)
     const days = Math.floor(hours / 24)

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -122,7 +122,7 @@ const Notification = ({ item, openCollaborativeScript, openSharedScript, close }
                     </div>
                     <div className="flex justify-between">
                         <div style={{ fontSize: "10px", color: "grey", float: "left" }}>
-                            {ESUtils.formatTime(Date.now() - item.time)}
+                            {ESUtils.humanReadableTimeAgo(item.time)}
                         </div>
 
                         {/* special actions */}
@@ -206,7 +206,6 @@ export const NotificationHistory = ({ openSharedScript, close }: {
 }) => {
     const notifications = useSelector(user.selectNotifications)
     const { t } = useTranslation()
-    const now = Date.now()
 
     return <div id="notification-history">
         <div className="flex justify-between" style={{ padding: "1em" }}>
@@ -233,7 +232,7 @@ export const NotificationHistory = ({ openSharedScript, close }: {
                     <div className="flex justify-between">
                         <div>
                             <div>{item.message.text}</div>
-                            <div style={{ fontSize: "10px", color: "grey" }}>{ESUtils.formatTime(now - item.time)}</div>
+                            <div style={{ fontSize: "10px", color: "grey" }}>{ESUtils.humanReadableTimeAgo(item.time)}</div>
                         </div>
                         {item.message.hyperlink && <div>
                             <a href={item.message.hyperlink} target="_blank" className="cursor-pointer" rel="noreferrer">{t("more").toLocaleUpperCase()}</a>
@@ -258,7 +257,7 @@ export const NotificationHistory = ({ openSharedScript, close }: {
                         <div>
                             <MarkdownLinkMessage text={item.message.text} />
                             <div style={{ fontSize: "10px", color: "grey" }}>
-                                {ESUtils.formatTime(now - item.time)}
+                                {ESUtils.humanReadableTimeAgo(item.time)}
                             </div>
                         </div>
                         {item.notification_type === "share_script" && <div>

--- a/src/user/notification.ts
+++ b/src/user/notification.ts
@@ -1,4 +1,3 @@
-import * as ESUtils from "../esutils"
 import store from "../reducers"
 import * as request from "../request"
 import { Notification, pushNotification, selectNotifications, setNotifications } from "./userState"
@@ -82,7 +81,7 @@ function loadHistory(notifications: Notification[]) {
             }
         }
 
-        v.time = ESUtils.parseDate(v.created!)
+        v.time = Date.parse(v.created!)
 
         // hack around only receiving notification history (collection) but not individual messages
         // TODO: always send individual notification from server

--- a/tests/jest/src/esutils.spec.js
+++ b/tests/jest/src/esutils.spec.js
@@ -44,15 +44,6 @@ test.each([
 })
 
 test.each([
-    { datestring: "2019-04-22 16:14:28.0Zxx", expected: 1555949668000 },
-    { datestring: "2022-03-04 14:14:14.6Zxx", expected: 1646403254600 },
-    { datestring: "2022-03-04 14:14:14.9Zxx", expected: 1646403254900 },
-    { datestring: "2000-05-26 01:01:01.1Zxx", expected: 959302861100 },
-])("parseDate($datestring)", ({ datestring, expected }) => {
-    expect(esutils.parseDate(datestring)).toBe(expected)
-})
-
-test.each([
     { value: 0.123456789, expected: 0.12346 },
     { value: 0.123, expected: 0.12300 },
 ])("toPrecision($value)", ({ value, expected }) => {


### PR DESCRIPTION
Removes the special handling of non-standard date formatting.

Fixes notifications, script history "NaN years ago" with the updated backend api.

Fixes todo for using a standard date format.
> TODO: Dates should be stored in a standard format in the database so as to make this unnecessary.

This is needed for our database update to MySQL 8. Relates to GTCMT/earsketch-api#84, which configures datetime fields to serialize as standard ISO 8601 date strings (yay!). The special handling of the old format breaks on the standard format.