### PR TITLE
Remove summit banner

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -976,9 +976,11 @@ export const App = () => {
                         <img className="h-[26px] mx-2.5 min-w-[41px]" src={esLogo} alt="EarSketch Logo"/>
                         <h1 className="text-2xl text-white">EarSketch</h1>
                     </a>
-                    <ConfettiLauncher/>
                     {FLAGS.SHOW_COMPETITION_BANNER && <HeaderBanner banner="earsketch-competition" />}
                 </div>
+
+                {/* for easter egg in passthrough.ts */}
+                <ConfettiLauncher/>
 
                 {/* temporary place for the app-generated notifications */}
                 <NotificationBar/>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -972,10 +972,7 @@ export const App = () => {
         <div className="flex flex-col justify-start h-screen max-h-screen">
             {!embedMode && <header role="banner" id="top-header-nav" className="shrink-0">
                 <div className="w-full flex items-center">
-                    <a href="http://earsketch.gatech.edu/landing"
-                        target="_blank" rel="noreferrer"
-                        className="flex items-center"
-                        tabIndex={0}>
+                    <a href="http://earsketch.gatech.edu/landing" target="_blank" rel="noreferrer" className="flex items-center" tabIndex={0}>
                         <img className="h-[26px] mx-2.5 min-w-[41px]" src={esLogo} alt="EarSketch Logo"/>
                         <h1 className="text-2xl text-white">EarSketch</h1>
                     </a>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -51,9 +51,9 @@ import { ModalBody, ModalFooter, ModalHeader, Prompt, PromptChoice } from "../Ut
 import * as websocket from "./websocket"
 
 import esLogo from "./ES_logo_extract.svg"
-import teachersLogo from "./teachers_logo.png"
 import LanguageDetector from "i18next-browser-languagedetector"
 import { AVAILABLE_LOCALES, ENGLISH_LOCALE } from "../locales/AvailableLocales";
+import HeaderBanner from "./HeaderBanner"
 
 // TODO: Temporary workaround for autograder and code analyzer, which replace the prompt function.
 (window as any).esPrompt = async (message: string) => {
@@ -450,46 +450,6 @@ function reportError() {
 
 function forgotPass() {
     openModal(ForgotPassword)
-}
-
-const HeaderBanner = ({ banner }: { banner: "earsketch-competition" | "summit" }) => {
-    if (banner === "earsketch-competition") {
-        return <EarSketchTeachersCompetitionBanner />
-    } else if (banner === "summit") {
-        return <EarSketchSummitBanner />
-    }
-    return null
-}
-
-const EarSketchTeachersCompetitionBanner = () => {
-    return (<div className="hidden w-full lg:flex justify-evenly">
-        <a href="https://www.teachers.earsketch.org/compete"
-            aria-label="Link to the competition website"
-            target="_blank"
-            className="text-black uppercase dark:text-white text-center"
-            style={{ color: "yellow", textShadow: "1px 1px #FF0000", lineHeight: "21px", fontSize: "18px" }}
-            rel="noreferrer">
-            <div className="flex flex-col items-center">
-                <img style={{ height: "20px" }} src={teachersLogo} id="comp-logo" alt="Link to the competition site"/>
-                <div>Remix Competition</div>
-            </div>
-        </a>
-    </div>)
-}
-
-const EarSketchSummitBanner = () => {
-    return (<div className="hidden w-full lg:flex justify-evenly">
-        <a href="https://gatech.zoom.us/webinar/register/7917465553949/WN_3Z4_z1OHR_2NexLYdccNvA"
-            aria-label="Link to EarSketch SUMMIT Registration"
-            target="_blank"
-            className="text-center"
-            rel="noreferrer">
-            <div className="flex flex-col items-center">
-                <div className="text-amber">JOIN US AT THE EARSKETCH SUMMIT</div>
-                <div className="text-gray-200 text-xs">MAY 21 &bull; 10AM-12PM ET</div>
-            </div>
-        </a>
-    </div>)
 }
 
 const KeyboardShortcuts = () => {
@@ -976,7 +936,7 @@ export const App = () => {
                         <img className="h-[26px] mx-2.5 min-w-[41px]" src={esLogo} alt="EarSketch Logo"/>
                         <h1 className="text-2xl text-white">EarSketch</h1>
                     </a>
-                    {FLAGS.SHOW_COMPETITION_BANNER && <HeaderBanner banner="earsketch-competition" />}
+                    {FLAGS.SHOW_COMPETITION_BANNER && <HeaderBanner />}
                 </div>
 
                 {/* for easter egg in passthrough.ts */}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -754,8 +754,6 @@ export const App = () => {
         dispatch(curriculum.open(url))
     }
 
-    const showAfeCompetitionBanner = FLAGS.SHOW_COMPETITION_BANNER || location.href.includes("competition")
-
     const sharedScriptID = ESUtils.getURLParameter("sharing")
 
     const changeLanguage = (lng: string) => {
@@ -982,7 +980,7 @@ export const App = () => {
                         <h1 className="text-2xl text-white">EarSketch</h1>
                     </a>
                     <ConfettiLauncher/>
-                    {showAfeCompetitionBanner && <HeaderBanner banner="earsketch-competition" />}
+                    {FLAGS.SHOW_COMPETITION_BANNER && <HeaderBanner banner="earsketch-competition" />}
                 </div>
 
                 {/* temporary place for the app-generated notifications */}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -452,6 +452,46 @@ function forgotPass() {
     openModal(ForgotPassword)
 }
 
+const HeaderBanner = ({ banner }: { banner: "earsketch-competition" | "summit" }) => {
+    if (banner === "earsketch-competition") {
+        return <EarSketchTeachersCompetitionBanner />
+    } else if (banner === "summit") {
+        return <EarSketchSummitBanner />
+    }
+    return null
+}
+
+const EarSketchTeachersCompetitionBanner = () => {
+    return (<div className="hidden w-full lg:flex justify-evenly">
+        <a href="https://www.teachers.earsketch.org/compete"
+            aria-label="Link to the competition website"
+            target="_blank"
+            className="text-black uppercase dark:text-white text-center"
+            style={{ color: "yellow", textShadow: "1px 1px #FF0000", lineHeight: "21px", fontSize: "18px" }}
+            rel="noreferrer">
+            <div className="flex flex-col items-center">
+                <img style={{ height: "20px" }} src={teachersLogo} id="comp-logo" alt="Link to the competition site"/>
+                <div>Remix Competition</div>
+            </div>
+        </a>
+    </div>)
+}
+
+const EarSketchSummitBanner = () => {
+    return (<div className="hidden w-full lg:flex justify-evenly">
+        <a href="https://gatech.zoom.us/webinar/register/7917465553949/WN_3Z4_z1OHR_2NexLYdccNvA"
+            aria-label="Link to EarSketch SUMMIT Registration"
+            target="_blank"
+            className="text-center"
+            rel="noreferrer">
+            <div className="flex flex-col items-center">
+                <div className="text-amber">JOIN US AT THE EARSKETCH SUMMIT</div>
+                <div className="text-gray-200 text-xs">MAY 21 &bull; 10AM-12PM ET</div>
+            </div>
+        </a>
+    </div>)
+}
+
 const KeyboardShortcuts = () => {
     const isMac = ESUtils.whichOS() === "MacOS"
     const modifier = isMac ? "Cmd" : "Ctrl"
@@ -942,37 +982,7 @@ export const App = () => {
                         <h1 className="text-2xl text-white">EarSketch</h1>
                     </a>
                     <ConfettiLauncher/>
-                    {showAfeCompetitionBanner &&
-                        <div className="hidden w-full lg:flex justify-evenly">
-                            <a href="https://www.teachers.earsketch.org/compete"
-                                aria-label="Link to the competition website"
-                                target="_blank"
-                                className="text-black uppercase dark:text-white text-center"
-                                style={{
-                                    color: "yellow",
-                                    textShadow: "1px 1px #FF0000",
-                                    lineHeight: "21px",
-                                    fontSize: "18px",
-                                }}
-                                rel="noreferrer">
-                                <div className="flex flex-col items-center">
-                                    <img style={{ height: "20px" }} src={teachersLogo} id="comp-logo"
-                                        alt="Link to the competition site"/>
-                                    <div>Remix Competition</div>
-                                </div>
-                            </a>
-                        </div>}
-                    <div className="hidden w-full lg:flex justify-evenly">
-                        <a href="https://gatech.zoom.us/webinar/register/7917465553949/WN_3Z4_z1OHR_2NexLYdccNvA"
-                            aria-label="Link to EarSketch SUMMIT Registration"
-                            target="_blank"
-                            className="text-center" rel="noreferrer">
-                            <div className="flex flex-col items-center">
-                                <div className="text-amber">JOIN US AT THE EARSKETCH SUMMIT</div>
-                                <div className="text-gray-200 text-xs">MAY 21 &bull; 10AM-12PM ET</div>
-                            </div>
-                        </a>
-                    </div>
+                    {showAfeCompetitionBanner && <HeaderBanner banner="earsketch-competition" />}
                 </div>
 
                 {/* temporary place for the app-generated notifications */}

--- a/src/app/HeaderBanner.tsx
+++ b/src/app/HeaderBanner.tsx
@@ -4,6 +4,7 @@ import teachersLogo from "./teachers_logo.png"
 
 /** Show the active banner */
 export const HeaderBanner = () => {
+    // No frills - just return whatever banner you want to be active
     return <EarSketchTeachersCompetitionBanner />
 }
 

--- a/src/app/HeaderBanner.tsx
+++ b/src/app/HeaderBanner.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+
+import teachersLogo from "./teachers_logo.png"
+
+/** Show the active banner */
+export const HeaderBanner = () => {
+    return <EarSketchTeachersCompetitionBanner />
+}
+
+/** A banner for competitions run by our team */
+export const EarSketchTeachersCompetitionBanner = () => {
+    return (<div className="hidden w-full lg:flex justify-evenly">
+        <a href="https://www.teachers.earsketch.org/compete"
+            aria-label="Link to the competition website"
+            target="_blank"
+            className="text-black uppercase dark:text-white text-center"
+            style={{ color: "yellow", textShadow: "1px 1px #FF0000", lineHeight: "21px", fontSize: "18px" }}
+            rel="noreferrer">
+            <div className="flex flex-col items-center">
+                <img style={{ height: "20px" }} src={teachersLogo} id="comp-logo" alt="Link to the competition site"/>
+                <div>Remix Competition</div>
+            </div>
+        </a>
+    </div>)
+}
+
+/** A banner linking to info about the EarSketch Summit */
+export const EarSketchSummitBanner = () => {
+    return (<div className="hidden w-full lg:flex justify-evenly">
+        <a href="https://gatech.zoom.us/webinar/register/7917465553949/WN_3Z4_z1OHR_2NexLYdccNvA"
+            aria-label="Link to EarSketch SUMMIT Registration"
+            target="_blank"
+            className="text-center"
+            rel="noreferrer">
+            <div className="flex flex-col items-center">
+                <div className="text-amber">JOIN US AT THE EARSKETCH SUMMIT</div>
+                <div className="text-gray-200 text-xs">MAY 21 &bull; 10AM-12PM ET</div>
+            </div>
+        </a>
+    </div>)
+}
+
+export default HeaderBanner


### PR DESCRIPTION
The summit banner has been removed, and also our header banners are now stored in a separate file for easy reference.

Makes sense as we expect to use the summit banner again in a year!