### PR TITLE
Avoid unnecessary requests for sound metadata

### DIFF
--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -54,8 +54,7 @@ export async function getSound(name: string): Promise<Sound> {
 }
 
 async function getSoundBuffer(sound: SoundEntity) {
-    // Using the public flag to determine "standard library" sounds. Could be improved.
-    const url = sound.public === 1
+    const url = sound.standard
         ? STATIC_AUDIO_URL_DOMAIN + "/" + sound.path
         : URL_DOMAIN + "/audio/sample?" + new URLSearchParams({ name: sound.name })
 
@@ -134,7 +133,7 @@ async function _getStandardSounds() {
         esconsole(`Fetched ${Object.keys(sounds).length} sounds in ${folders.length} folders`, ["debug", "audiolibrary"])
         // Populate cache with standard sound metadata so that we don't fetch it again later via `getMetadata()`.
         for (const sound of sounds) {
-            fixMetadata(sound)
+            fixMetadata(sound, true)
             if (!cache.sounds[sound.name]) {
                 cache.sounds[sound.name] = { metadata: Promise.resolve(sound) }
             }
@@ -174,14 +173,15 @@ async function _getMetadata(name: string) {
         return null
     }
 
-    fixMetadata(metadata)
+    fixMetadata(metadata, false)
     return metadata
 }
 
-function fixMetadata(metadata: SoundEntity) {
+function fixMetadata(metadata: SoundEntity, standard: boolean) {
     // Server uses -1 to indicate no tempo; for type safety, we remap this to undefined.
     if (metadata.tempo === -1) {
         metadata.tempo = undefined
     }
+    metadata.standard = standard
     return metadata
 }

--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -129,7 +129,7 @@ async function _getStandardSounds() {
     esconsole("Fetching standard sound metadata", ["debug", "audiolibrary"])
     try {
         const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard.json"
-        const sounds: SoundEntity[] = await (await fetch(url)).json()
+        let sounds: SoundEntity[] = await (await fetch(url)).json()
         const folders = [...new Set(sounds.map(entity => entity.folder))]
         esconsole(`Fetched ${Object.keys(sounds).length} sounds in ${folders.length} folders`, ["debug", "audiolibrary"])
         // Populate cache with standard sound metadata so that we don't fetch it again later via `getMetadata()`.
@@ -139,6 +139,9 @@ async function _getStandardSounds() {
                 cache.sounds[sound.name] = { metadata: Promise.resolve(sound) }
             }
         }
+        // Filter out "non-public" sounds so that they don't appear in the sound browser, autocomplete, etc.
+        // Note that we still cache their metadata above; this just prevents them from appearing in the standard set.)
+        sounds = sounds.filter(sound => sound.public)
         return { sounds, folders }
     } catch (err: any) {
         esconsole("HTTP status: " + err.status, ["error", "audiolibrary"])

--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -9,59 +9,55 @@ const STATIC_AUDIO_URL_DOMAIN = URL_DOMAIN === "https://api.ersktch.gatech.edu/E
 
 export type Sound = SoundEntity & { buffer: AudioBuffer }
 
+// NOTE: We always fetch sound metadata before fetching audio,
+// but sometimes we fetch metadata *without* fetching audio.
+// This is why `metadata` is required but `buffer` is optional.
+interface SoundPromises {
+    metadata: Promise<SoundEntity | null>
+    buffer?: Promise<AudioBuffer>
+}
+
 export const cache = {
     // We cache promises (rather than results) so we don't launch a second request while waiting on the first request.
     standardSounds: null as Promise<{ sounds: SoundEntity[], folders: string[] }> | null,
-    promises: Object.create(null) as { [key: string]: Promise<Sound> },
+    sounds: Object.create(null) as { [key: string]: SoundPromises },
 }
 
 // Get an audio buffer from a file key.
 //   filekey: The constant associated with the audio clip that users type in EarSketch code.
 //   tempo: Tempo to scale the returned clip to.
-export function getSound(filekey: string) {
-    // Cache hit. A request for this sound is already in-progress/complete.
-    const promiseFromCache = cache.promises[filekey]
-    if (promiseFromCache) return promiseFromCache
+export async function getSound(name: string): Promise<Sound> {
+    // Start by getting the sound metadata.
+    getMetadata(name)
+    const cached = cache.sounds[name]
 
-    // Cache miss. Store promise immediately to prevent new duplicate requests.
-    const promise = _getSound(filekey)
-    cache.promises[filekey] = promise
+    if (!cached.buffer) {
+        // A request for the sound metadata is already in progress or complete;
+        // now we just need to take on a request for the sound buffer.
+        cached.buffer = cached.metadata.then(sound => {
+            if (sound === null) {
+                throw new ReferenceError(`Sound ${name} does not exist`)
+            }
+            return getSoundBuffer(sound)
+        }).catch(error => {
+            // Request failed. Remove from cache so future requests can try again.
+            cached.buffer = undefined
+            throw error
+        })
+    }
 
-    return promise.catch(error => {
-        // Request failed. Remove from cache so future requests can try again.
-        delete cache.promises[filekey]
-        throw error
-    })
+    const buffer = await cached.buffer
+    return {
+        ...(await cached.metadata)!,
+        buffer,
+    }
 }
 
-async function _getSound(name: string) {
-    esconsole("Loading audio: " + name, ["debug", "audiolibrary"])
-
-    // STEP 1: check if sound exists
-    // TODO: Sample download includes clip verification on server side, so probably we can skip the first part.
-    let result
-    try {
-        result = await getMetadata(name)
-    } catch (err) {
-        esconsole("Error getting sound: " + name, ["error", "audiolibrary"])
-        throw err
-    }
-    if (result === null) {
-        throw new ReferenceError(`Sound ${name} does not exist`)
-    }
-
-    // Server uses -1 to indicate no tempo; for type-safety, we remap this to undefined.
-    if (result.tempo === -1) {
-        result.tempo = undefined
-    }
-
-    // STEP 2: Ask the server for the audio file
-    esconsole(`Getting ${name} buffer from server`, ["debug", "audiolibrary"])
-
+async function getSoundBuffer(sound: SoundEntity) {
     // Using the public flag to determine "standard library" sounds. Could be improved.
-    const url = result.public === 1
-        ? STATIC_AUDIO_URL_DOMAIN + "/" + result.path
-        : URL_DOMAIN + "/audio/sample?" + new URLSearchParams({ name })
+    const url = sound.public === 1
+        ? STATIC_AUDIO_URL_DOMAIN + "/" + sound.path
+        : URL_DOMAIN + "/audio/sample?" + new URLSearchParams({ name: sound.name })
 
     let data: ArrayBuffer
     try {
@@ -83,7 +79,7 @@ async function _getSound(name: string) {
     // Check for MP3 file signatures.
     const isMP3 = (bytes[0] === 0x49 && bytes[1] === 0x44 && bytes[2] === 0x33) || (bytes[0] === 0xff || bytes[1] === 0xfb)
 
-    // STEP 3: decode the audio data.
+    // Decode the audio data.
     esconsole(`Decoding ${name} buffer`, ["debug", "audiolibrary"])
     let buffer: AudioBuffer
     try {
@@ -104,15 +100,13 @@ async function _getSound(name: string) {
         buffer.copyToChannel(fixed, 0)
     }
 
-    // STEP 4: Return the sound metadata and decoded audio buffer.
-    esconsole("Returning sound", ["debug", "audiolibrary"])
-    return { ...result, buffer }
+    return buffer
 }
 
 export function clearCache() {
     esconsole("Clearing the cache", ["debug", "audiolibrary"])
     cache.standardSounds = null
-    cache.promises = {} // this might be overkill, but otherwise deleted / renamed sound cache is still accessible
+    cache.sounds = {} // this might be overkill, but otherwise deleted / renamed sound cache is still accessible
 }
 
 export function getStandardSounds() {
@@ -138,6 +132,7 @@ async function _getStandardSounds() {
         const sounds: SoundEntity[] = await (await fetch(url)).json()
         const folders = [...new Set(sounds.map(entity => entity.folder))]
         esconsole(`Fetched ${Object.keys(sounds).length} sounds in ${folders.length} folders`, ["debug", "audiolibrary"])
+        // TODO populate cache so that we don't fetch metadata for standard sounds again
         return { sounds, folders }
     } catch (err: any) {
         esconsole("HTTP status: " + err.status, ["error", "audiolibrary"])
@@ -147,6 +142,15 @@ async function _getStandardSounds() {
 
 export async function getMetadata(name: string) {
     esconsole("Verifying the presence of audio clip for " + name, ["debug", "audiolibrary"])
+    let cached = cache.sounds[name]
+    if (cached === undefined) {
+        // Cache miss. Store promise immediately to prevent new duplicate requests.
+        cached = cache.sounds[name] = { metadata: _getMetadata(name) }
+    }
+    return cached.metadata
+}
+
+async function _getMetadata(name: string) {
     const url = URL_DOMAIN + "/audio/metadata?" + new URLSearchParams({ name })
     const response = await fetch(url)
     const text = await response.text()
@@ -156,5 +160,14 @@ export async function getMetadata(name: string) {
         return null
     }
     const data: SoundEntity = JSON.parse(text)
-    return "name" in data ? data : null
+    if (!Object.prototype.hasOwnProperty.call(data, "name")) {
+        // TODO: do we still need this check? seems like this should never happen
+        return null
+    }
+
+    // Server uses -1 to indicate no tempo; for type-safety, we remap this to undefined.
+    if (data.tempo === -1) {
+        data.tempo = undefined
+    }
+    return data
 }

--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -166,7 +166,7 @@ async function _getMetadata(name: string) {
         return null
     }
     const metadata: SoundEntity = JSON.parse(text)
-    if (!Object.prototype.hasOwnProperty.call(metadata, "name")) {
+    if (!("name" in metadata)) {
         // TODO: do we still need this check? seems like this should never happen
         return null
     }

--- a/src/app/postRun.ts
+++ b/src/app/postRun.ts
@@ -47,7 +47,7 @@ export async function loadBuffersForTransformedClips(result: DAWData) {
 
     for (const [key, def] of Object.entries(result.transformedClips)) {
         // Fetch the sound data for transformed clips
-        if (key in audioLibrary.cache.promises) continue // Already transformed
+        if (key in audioLibrary.cache.sounds) continue // Already transformed
         const promise: Promise<[string, TransformedClip, audioLibrary.Sound]> =
             audioLibrary.getSound(def.sourceKey).then(sound => [key, def, sound])
         promises.push(promise)
@@ -79,7 +79,10 @@ export async function loadBuffersForTransformedClips(result: DAWData) {
                 tempo = undefined
             }
         }
-        audioLibrary.cache.promises[key] = Promise.resolve({ ...sound, file_key: key, buffer, tempo })
+        audioLibrary.cache.sounds[key] = {
+            metadata: Promise.resolve({ ...sound, file_key: key, tempo }),
+            buffer: Promise.resolve(buffer),
+        }
     }
 }
 

--- a/src/app/runner.ts
+++ b/src/app/runner.ts
@@ -52,7 +52,7 @@ class SoundConstantFinder extends NodeVisitor {
 }
 
 // Searches for identifiers that might be sound constants, verifies with the server, and inserts into globals.
-async function handleSoundConstantsPY(code: string) {
+async function handleSoundConstantsPython(code: string) {
     // First, inject sound constants that refer to folders, since the server doesn't handle them on the metadata endpoint.
     for (const constant of (await audioLibrary.getStandardSounds()).folders) {
         Sk.builtins[constant] = Sk.ffi.remapToPy(constant)
@@ -100,7 +100,7 @@ async function runPython(code: string) {
         throw new Error("finish()" + i18n.t("messages:interpreter.noimport"))
     })
 
-    await handleSoundConstantsPY(code)
+    await handleSoundConstantsPython(code)
 
     const lines = code.match(/\n/g) ? code.match(/\n/g)!.length + 1 : 1
     esconsole("Running " + lines + " lines of Python", ["debug", "runner"])
@@ -149,7 +149,7 @@ async function runPython(code: string) {
 }
 
 // Searches for identifiers that might be sound constants, verifies with the server, and inserts into globals.
-async function handleSoundConstantsJS(code: string, interpreter: any) {
+async function handleSoundConstantsJavaScript(code: string, interpreter: any) {
     // First, inject sound constants that refer to folders, since the server doesn't handle them on the metadata endpoint.
     const scope = interpreter.getScope().object
     for (const constant of (await audioLibrary.getStandardSounds()).folders) {
@@ -200,7 +200,7 @@ function createJsInterpreter(code: string) {
 async function runJavaScript(code: string) {
     esconsole("Running script using JS-Interpreter.", ["debug", "runner"])
     const mainInterpreter = createJsInterpreter(code)
-    await handleSoundConstantsJS(code, mainInterpreter)
+    await handleSoundConstantsJavaScript(code, mainInterpreter)
     getLineNumber = () => {
         const stateStack = mainInterpreter.stateStack
         return stateStack[stateStack.length - 1].node.loc.start.line

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,13 +33,13 @@ export interface SoundEntity {
     folder: string
     artist: string
     year: string
-    public: number
+    public: number // Should this appear in the sound browser, autocomplete, etc.?
     genre: string
     instrument: string
     keySignature?: string
     keyConfidence?: number
-    // TODO: Server should omit or set to null to indicate no tempo, rather than -1.
-    tempo?: number
+    tempo?: number // TODO: Server should omit or set to null to indicate no tempo, rather than -1.
+    standard: boolean // Is this a standard sound (as opposed to a user sound)? (client-only flag)
 }
 
 export interface Clip {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -101,20 +101,17 @@ Cypress.Commands.add("login", (username = TEST_USER) => {
  * @param [standardAudioLibrary=DUBSTEP_BASS_WOBBLE_002]
  * @returns Chainable
  */
-Cypress.Commands.add("interceptAudioStandard", (standardAudioLibrary = [
-    {
-        artist: "RICHARD DEVINE",
-        folder: "DUBSTEP_140_BPM__DUBBASSWOBBLE",
-        genre: "DUBSTEP",
-        genreGroup: "DUBSTEP",
-        instrument: "SYNTH",
-        name: "DUBSTEP_BASS_WOBBLE_002",
-        path: "filename/placeholder/here.wav",
-        public: 1,
-        tempo: 140,
-        year: 2012,
-    },
-]) => {
+Cypress.Commands.add("interceptAudioStandard", (sounds = []) => {
+    const standardAudioLibrary = sounds.concat([
+        ...[1, 2].map(i => ({
+            artist: "EARSKETCH",
+            folder: "EARSKETCH",
+            name: `METRONOME0${i}`,
+            path: `standard-library/EarSketch/METRONOME0${i}.flac`,
+            public: 0,
+            tempo: -1,
+        })),
+    ])
     cy.intercept(
         {
             hostname: CLOUDFRONT_HOST,
@@ -302,7 +299,10 @@ Cypress.Commands.add("interceptScriptById", (script) => {
 Cypress.Commands.add("interceptAudioMetadata", (testSoundMeta) => {
     cy.intercept(
         { method: "GET", hostname: API_HOST, path: "/EarSketchWS/audio/metadata?name=*" },
-        { body: testSoundMeta }
+        req => {
+            const name = new URLSearchParams(req.url).name
+            req.reply(name === testSoundMeta.name ? testSoundMeta : "")
+        }
     ).as("audio_metadata")
 })
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -102,16 +102,14 @@ Cypress.Commands.add("login", (username = TEST_USER) => {
  * @returns Chainable
  */
 Cypress.Commands.add("interceptAudioStandard", (sounds = []) => {
-    const standardAudioLibrary = sounds.concat([
-        ...[1, 2].map(i => ({
-            artist: "EARSKETCH",
-            folder: "EARSKETCH",
-            name: `METRONOME0${i}`,
-            path: `standard-library/EarSketch/METRONOME0${i}.flac`,
-            public: 0,
-            tempo: -1,
-        })),
-    ])
+    const standardAudioLibrary = sounds.concat([1, 2].map(i => ({
+        artist: "EARSKETCH",
+        folder: "EARSKETCH",
+        name: `METRONOME0${i}`,
+        path: `standard-library/EarSketch/METRONOME0${i}.flac`,
+        public: 0,
+        tempo: -1,
+    })))
     cy.intercept(
         {
             hostname: CLOUDFRONT_HOST,


### PR DESCRIPTION
Fixes GTCMT/earsketch#3461. Also fixes an issue where we were calling `/audio/sample` for `METRONOME01` and `METRONOME02` rather than fetching them from static storage.

## Requests to `/audio/metadata` from running `quick_tour.py`:
### Before:
![Screenshot from 2025-06-12 10-57-23](https://github.com/user-attachments/assets/098c3d3d-61ea-4ecb-97fc-5a566591248d)

### After caching metadata:
![Screenshot from 2025-06-12 12-08-44](https://github.com/user-attachments/assets/bc2cd281-bc8f-43f5-b13a-7c61151634f9)

### After using already-fetched metadata for standard sounds:
![Screenshot from 2025-06-12 12-29-33](https://github.com/user-attachments/assets/55c87fcf-06af-4744-98f6-cbfc8fc84c3c)

### After adding `METRONOME01`/`METRONOME02` to standard sounds (thanks @manodrum):
![image](https://github.com/user-attachments/assets/eaf3836f-d97f-45f4-b9d2-231beadf08fc)

Ta-da!

Note that we'll also need to do this on prod.