### PR TITLE
Cache user sound metadata to avoid unnecessary requests

### DIFF
--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -148,6 +148,19 @@ async function _getStandardSounds() {
     }
 }
 
+export async function getUserSounds(username: string) {
+    const response = await fetch(URL_DOMAIN + "/audio/user?" + new URLSearchParams({ username }))
+    const sounds: SoundEntity[] = await response.json()
+    // Populate cache with user sound metadata so that we don't fetch it again later via `getMetadata()`.
+    for (const sound of sounds) {
+        fixMetadata(sound, false)
+        if (!cache.sounds[sound.name]) {
+            cache.sounds[sound.name] = { metadata: Promise.resolve(sound) }
+        }
+    }
+    return sounds
+}
+
 export async function getMetadata(name: string) {
     esconsole("Verifying the presence of audio clip for " + name, ["debug", "audiolibrary"])
     let cached = cache.sounds[name]

--- a/src/browser/soundsThunks.ts
+++ b/src/browser/soundsThunks.ts
@@ -43,21 +43,13 @@ export const getStandardSounds = createAsyncThunk<void, void, ThunkAPI>(
 export const getUserSounds = createAsyncThunk<void, string, ThunkAPI>(
     "sounds/getUserSounds",
     async (username, { dispatch }) => {
-        const endPoint = URL_DOMAIN + "/audio/user"
-        const params = new URLSearchParams({ username })
-        const response = await fetch(`${endPoint}?${params}`, {
-            method: "GET",
-            cache: "default",
-        })
-        const data = await response.json()
-
+        const data = await audioLibrary.getUserSounds(username)
         const entities: { [key: string]: SoundEntity; } = {}
         const names = new Array(data.length)
-
-        data.forEach((sound: SoundEntity, i: number) => {
+        for (const [i, sound] of data.entries()) {
             entities[sound.name] = sound
             names[i] = sound.name
-        })
+        }
 
         dispatch(setUserSounds({ entities, names }))
     }


### PR DESCRIPTION
More on GTCMT/earsketch#3461.

A couple of related observations:
- Currently anyone, even if they're not logged in, can use `/audio/user` to see any user's sounds; [here's an example](https://api.ersktch.gatech.edu/EarSketchWS/audio/user?username=ijc). Do we want to restrict this to just the user who uploaded them? (If so, the query parameter would become redundant.)
- Standard sound folders are injected as constants (e.g. `ALT_POP_GUITAR` or `ALICIA_KEYS_UNDERDOG_VOCALS`), presumably for use with `selectRandomFile()`. However, the user's own folder name (`IJC`, `HEERMAN`, etc.) is not. This seems like an omission, but it makes sense given that `selectRandomFile()` only works on standard sounds (and we probably want to keep it that way to ensure consistent behavior from shared scripts).