### PR TITLE
Bug fix: editor change tracking

### DIFF
--- a/tests/cypress/e2e/editor.cy.js
+++ b/tests/cypress/e2e/editor.cy.js
@@ -120,7 +120,7 @@ makeBeat(OS_CLAP01, 1, 1, "0000", 4)
         cy.get("@audio_sample.all").should("have.length", 3)
     })
 
-    it.only("allows user to login, edit script, and save", () => {
+    it("allows user to login, edit script, and save", () => {
         const username = "cypress"
         const scriptName = "RecursiveMelody.py"
 

--- a/tests/cypress/e2e/editor.cy.js
+++ b/tests/cypress/e2e/editor.cy.js
@@ -147,7 +147,6 @@ makeBeat(OS_CLAP01, 1, 1, "0000", 4)
         }])
 
         cy.interceptAudioUser()
-
         // Login with placeholder username
         cy.login("username")
         // wait for the already created script to be saved during login
@@ -169,5 +168,23 @@ makeBeat(OS_CLAP01, 1, 1, "0000", 4)
 
         cy.get("#console-frame").contains(message)
         cy.get('[data-test="notificationBar"]').contains("Script ran successfully")
+
+        const message2 = "another message"
+        cy.get("#editor").type(`{moveToEnd}{enter}print("${message2}")`)
+
+        cy.get("button").contains("button", scriptName).parent().should("have.class", "text-red-500")
+
+        if (Cypress.platform === "darwin") {
+            cy.get("#editor").type("{meta+s}")
+        } else {
+            cy.get("#editor").type("{ctrl+s}")
+        }
+
+        cy.wait("@scripts_save").then((interception) => {
+            expect(interception.request.body).to.contain(`name=${scriptName}`)
+            expect(interception.request.body.replaceAll("+", " ")).to.contain(message2)
+        })
+
+        cy.get("#console-frame").should("not.contain", message2)
     })
 })

--- a/tests/cypress/e2e/editor.cy.js
+++ b/tests/cypress/e2e/editor.cy.js
@@ -10,7 +10,6 @@ describe("Editor", () => {
         cy.interceptAudioStandard([testSoundMeta])
         cy.interceptAudioMetadata(testSoundMeta)
         cy.interceptAudioSample()
-
         cy.visit("/")
         cy.skipTour()
         // Create a new script.
@@ -119,5 +118,56 @@ makeBeat(OS_CLAP01, 1, 1, "0000", 4)
         // We expect 3 intercepted calls: METRONOME01, METRONOME02, and OS_CLAP01
         // https://github.com/cypress-io/cypress/issues/16655
         cy.get("@audio_sample.all").should("have.length", 3)
+    })
+
+    it.only("allows user to login, edit script, and save with run button", () => {
+        const username = "cypress"
+        const scriptName = "RecursiveMelody.py"
+
+        // Setup intercepts for login and save
+        cy.interceptScriptSave(scriptName)
+        cy.interceptUsersToken()
+        cy.interceptUsersInfo(username)
+        cy.interceptAudioUser([])
+        cy.interceptAudioFavorites()
+        cy.interceptScriptsShared()
+        cy.interceptAudioUpload()
+
+        cy.interceptScriptsOwned([{
+            created: "2022-01-02 16:20:00.0",
+            file_location: "",
+            id: -1,
+            modified: "2022-02-14 16:19:00.0",
+            name: scriptName,
+            run_status: 1,
+            shareid: "1111111111111111111111",
+            soft_delete: false,
+            source_code: "from earsketch import *\nsetTempo(91)\n",
+            username,
+        }])
+
+        cy.interceptAudioUser()
+
+        // Login with placeholder username
+        cy.login("username")
+        // wait for the already created script to be saved during login
+        cy.wait("@scripts_save")
+        cy.get(`[title="Open ${scriptName} in Code Editor"]`).click()
+
+        const message = "Hello from saved script"
+        cy.get("#editor").type(`{moveToEnd}{enter}print("${message}")`)
+
+        cy.get("button").contains("button", scriptName).parent().should("have.class", "text-red-500")
+
+        // NOTE: Clicking "RUN" instead of using Ctrl+Enter because the shortcut is different on Mac.
+        cy.get("button").contains("RUN").click()
+        // Verify the save API was called
+        cy.wait("@scripts_save").then((interception) => {
+            expect(interception.request.body).to.contain(`name=${scriptName}`)
+            expect(interception.request.body.replaceAll("+", " ")).to.contain(message)
+        })
+
+        cy.get("#console-frame").contains(message)
+        cy.get('[data-test="notificationBar"]').contains("Script ran successfully")
     })
 })

--- a/tests/cypress/e2e/editor.cy.js
+++ b/tests/cypress/e2e/editor.cy.js
@@ -120,7 +120,7 @@ makeBeat(OS_CLAP01, 1, 1, "0000", 4)
         cy.get("@audio_sample.all").should("have.length", 3)
     })
 
-    it.only("allows user to login, edit script, and save with run button", () => {
+    it.only("allows user to login, edit script, and save", () => {
         const username = "cypress"
         const scriptName = "RecursiveMelody.py"
 


### PR DESCRIPTION
💡 Idea!💡 

We should save users' changes to their scripts :)

This restores CodeMirror change tracking and calling our edit callback, along with a handy cypress test so we can hope we don't unknowingly delete this feature in the future.

Resolves GTCMT/earsketch#3524.