### PR TITLE
Autograder Fix for `sourceLine`

### DIFF
--- a/src/app/Autograder.tsx
+++ b/src/app/Autograder.tsx
@@ -99,6 +99,18 @@ const compare = (reference: DAWData, test: DAWData, testAllTracks: boolean, test
             clip.sourceLine = 0
         }
     }
+
+    // remove sourceLine property from effects
+    for (const track of reference.tracks.concat(test.tracks)) {
+        for (const effect of Object.keys(track.effects)) {
+            for (const effectParam of Object.keys(track.effects[effect])) {
+                for (const paramValues in track.effects[effect][effectParam]) {
+                    track.effects[effect][effectParam][paramValues].sourceLine = 0
+                }
+            }
+        }
+    }
+
     return JSON.stringify(reference) === JSON.stringify(test)
 }
 


### PR DESCRIPTION
`sourceLine` can throw off otherwise identical scripts that have code on different line numbers. This was resolved for tracks a year ago based on autograder user feedback, but also needs to be resolved for effects.