### PR TITLE
Silent audio download bug fix

### DIFF
--- a/src/audio/renderer.ts
+++ b/src/audio/renderer.ts
@@ -24,6 +24,7 @@ export async function renderBuffer(dawData: DAWData) {
     await context.audioWorklet.addModule(pitchshiftWorkletURL)
 
     const out = new GainNode(context)
+    out.connect(context.destination)
     const projectGraph: ProjectGraph = {
         tracks: [],
         mix: new GainNode(context),


### PR DESCRIPTION
Fixes bug : "Downloading WAV, MP3, or Multitrack from EarSketch results in silent audio files" inadvertently introduced in PR #740 