### PR TITLE
Added line to index.html to display missing favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <script type="text/javascript" src="newrelic/newrelicbrowser.%ES_NEWRELIC_CONFIG%.js"></script>
     <title>EarSketch</title>
+    <link rel="icon" href="/favicon.ico" />
     <style>
         .es-spinner {
             background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" version="1.1" id="svg8" viewBox="0 0 120 120"%3E%3Cstyle id="style959"/%3E%3Cg id="layer1" transform="translate(-30 -30)" fill-opacity="1" stroke-width="1"%3E%3Cpath id="path931" d="M46 90H30a60 60 0 0060 60v-16a44 44 0 01-44-44z" fill="%234286da"/%3E%3Cpath id="path953" d="M90 30a60 60 0 00-60 60h16a44 44 0 0144-44V30z" fill="%23f3f3f3"/%3E%3Cpath id="path950" d="M150 90h-16a44 44 0 01-44 44v16a60 60 0 0060-60z" fill="%23f3f3f3"/%3E%3Cpath id="path956" d="M90 30v16a44 44 0 0144 44h16a60 60 0 00-60-60z" fill="%234286da"/%3E%3C/g%3E%3C/svg%3E');


### PR DESCRIPTION
Browser tab favicon has been missing in build and prod versions of earsketch (see screenshots)
Test code with `npm run build` -> `npm run preview` or see current deployment

<img width="644" height="88" alt="Screenshot 2025-11-09 at 11 53 15 PM" src="https://github.com/user-attachments/assets/0fa81945-e6ae-4414-96c9-a39ef0b0f89d" />
<img width="644" height="88" alt="Screenshot 2025-11-09 at 11 53 21 PM" src="https://github.com/user-attachments/assets/bdb683c9-1e19-4dee-adac-28c515ed7afd" />
<img width="644" height="88" alt="Screenshot 2025-11-09 at 11 54 04 PM" src="https://github.com/user-attachments/assets/26fe204d-6bab-454c-a261-3430af7f7d98" />
