### PR TITLE
Add `_1` to audio-standard

### DIFF
--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -128,7 +128,7 @@ export function getStandardSounds() {
 async function _getStandardSounds() {
     esconsole("Fetching standard sound metadata", ["debug", "audiolibrary"])
     try {
-        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard.json"
+        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard_1.json"
         const response = await fetch(url)
         if (!response.ok) {
             throw Object.assign(new Error(`Failed to fetch standard sounds (code ${response.status}).`), { code: response.status })

--- a/tests/cypress/e2e/sound-browser.cy.js
+++ b/tests/cypress/e2e/sound-browser.cy.js
@@ -24,7 +24,7 @@ describe("preview sound", () => {
         cy.skipTour()
 
         // wait for all audio library api calls to finish
-        cy.waitForNetworkIdle("/backend-static/audio-standard.json", 2000)
+        cy.waitForNetworkIdle("/backend-static/audio-standard_1.json", 2000)
         // preview sound
         cy.get("i.icon.icon-play4") // confirms audio is not playing
         cy.get("button[title='Preview sound']").realClick()

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -114,7 +114,7 @@ Cypress.Commands.add("interceptAudioStandard", (sounds = []) => {
         {
             hostname: CLOUDFRONT_HOST,
             method: "GET",
-            path: "/backend-static/audio-standard.json",
+            path: "/backend-static/audio-standard_1.json",
         },
         {
             body: standardAudioLibrary,


### PR DESCRIPTION
to bust the cache one time to deal with the 123 Andres rollout.