### PR TITLE
Prevent infinite render loops by the script menu modals

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -850,7 +850,10 @@ export const ModalContainer = () => {
 
     const close = () => {
         setClosing(true)
-        resolve(undefined) // This has no effect if the modal already resolved with a payload.
+
+        // Bug fix: Guard `resolve` so it is only called once, or risk an infinite render loop in firefox.
+        resolve?.(undefined)
+
         setTimeout(() => {
             if (modalData === appState.selectModal(store.getState())) {
                 dispatch(appState.setModal(null))


### PR DESCRIPTION
Bug fix: Guard `resolve` so it is only called once

`close()` is often triggered multiple times by the framework.

Calling it after the modal has already closed caused a render loop and crashes firefox, probably silently churning in other browsers.

`onClose -> resolve() -> state update -> rerender -> onClose -> resolve() -> ...`
instead of
`onClose -> close -> (resolve is null) -> stop`

Relates to GTCMT/earsketch#3630.