### PR TITLE
Check that user token is null before showing quick tour

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -576,6 +576,8 @@ export const App = () => {
         (async () => {
             document.getElementById("loading-screen")!.style.display = "none"
 
+            const token = user.selectToken(store.getState())
+
             // Attempt to load userdata from a previous session.
             if (savedLoginInfo) {
                 await login({ username, password }).then(() => {
@@ -590,7 +592,6 @@ export const App = () => {
                     }
                 })
             } else {
-                const token = user.selectToken(store.getState())
                 if (token !== null) {
                     await login({ token })
                 }
@@ -606,8 +607,8 @@ export const App = () => {
                         store.dispatch(tabThunks.closeAndSwitchTab(scriptID))
                     }
                 }
-                // Show bubble tutorial when not opening a share link or in a CAI study mode.
-                if (Object.keys(allScripts).length === 0 && !sharedScriptID && !ES_WEB_SHOW_CAI && !ES_WEB_SHOW_CHAT) {
+                // Only show bubble tutorial when not logged in (user token not set), not opening a share link, or in a CAI study mode.
+                if (token == null && Object.keys(allScripts).length === 0 && !sharedScriptID && !ES_WEB_SHOW_CAI && !ES_WEB_SHOW_CHAT) {
                     store.dispatch(bubble.resume())
                 }
             }


### PR DESCRIPTION
Addresses [#3634](https://github.com/GTCMT/earsketch/issues/3634)

Ensures that quick tour does not show up on `npm run dev` unless user is not automagically logged in (which may still happen on eduroam)