### PR TITLE
Update daw diffs i18n value for bug fix

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -550,10 +550,10 @@
       "trackEffectEnvelopePointRemoved": "Track {{trackNum}}: Removed {{count}} envelope point from {{effect}} {{effectParam}}",
       "trackEffectEnvelopePointRemoved_plural": "Track {{trackNum}}: Removed {{count}} envelope points from {{effect}} {{effectParam}}",
       "trackEffectEnvelopeChanged": "Track {{trackNum}}: Envelope changed for effect {{effect}} {{effectParam}}",
-      "trackClipsChanged": "Track {{trackNum}}: Changed audio files {{addedText}}{{removedText}}. Track spans measures {{spanStart}} to {{spanEnd}}",
+      "trackClipsChanged": "Track {{trackNum}}: Changed audio files. {{addedText}}. {{removedText}}. Track spans measures {{spanStart}} to {{spanEnd}}",
       "trackClipsPositionChanged": "Track {{trackNum}}: Sound positions changed ({{filekeys}}). Track spans measures {{spanStart}} to {{spanEnd}}",
-      "clipFilesAdded": ". Added: {{filekeys}}",
-      "clipFilesRemoved": ". Removed: {{filekeys}}",
+      "clipFilesAdded": "Added: {{filekeys}}",
+      "clipFilesRemoved": "Removed: {{filekeys}}",
       "tempoChanged": "Project tempo changed"
     },
     "shareScript": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -550,7 +550,7 @@
       "trackEffectEnvelopePointRemoved": "Track {{trackNum}}: Removed {{count}} envelope point from {{effect}} {{effectParam}}",
       "trackEffectEnvelopePointRemoved_plural": "Track {{trackNum}}: Removed {{count}} envelope points from {{effect}} {{effectParam}}",
       "trackEffectEnvelopeChanged": "Track {{trackNum}}: Envelope changed for effect {{effect}} {{effectParam}}",
-      "trackClipsChanged": "Track {{trackNum}}: Changed audio files ({{measures}} measures){{addedText}}{{removedText}}. Track spans measures {{spanStart}} to {{spanEnd}}",
+      "trackClipsChanged": "Track {{trackNum}}: Changed audio files {{addedText}}{{removedText}}. Track spans measures {{spanStart}} to {{spanEnd}}",
       "trackClipsPositionChanged": "Track {{trackNum}}: Sound positions changed ({{filekeys}}). Track spans measures {{spanStart}} to {{spanEnd}}",
       "clipFilesAdded": ". Added: {{filekeys}}",
       "clipFilesRemoved": ". Removed: {{filekeys}}",

--- a/tests/vitest/fixtures/dawDiffScripts/baseline-change-sound.json
+++ b/tests/vitest/fixtures/dawDiffScripts/baseline-change-sound.json
@@ -1,0 +1,802 @@
+{
+  "init": true,
+  "finish": false,
+  "length": 8,
+  "tracks": [
+    {
+      "effects": {
+        "TEMPO": {
+          "TEMPO": [
+            {
+              "measure": 1,
+              "value": 120,
+              "shape": "square",
+              "sourceLine": 1
+            },
+            {
+              "measure": 1,
+              "value": 120,
+              "shape": "square",
+              "sourceLine": 7
+            }
+          ]
+        }
+      },
+      "clips": [
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 1,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 1.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 1.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 1.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 2,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 2.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 2.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 2.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 3,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 3.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 3.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 3.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 4,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 4.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 4.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 4.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 5.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 5.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 5.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 6,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 6.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 6.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 6.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 7,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 7.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 7.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 7.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME01",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 8,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 8.25,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 8.5,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        },
+        {
+          "filekey": "METRONOME02",
+          "sourceAudio": {},
+          "audio": {},
+          "track": 0,
+          "measure": 8.75,
+          "start": 1,
+          "end": 1.625,
+          "scale": false,
+          "loop": false,
+          "loopChild": false
+        }
+      ]
+    },
+    {
+      "clips": [
+        {
+          "filekey": "RD_POP_SYNTHBASS_6",
+          "track": 1,
+          "measure": 1,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 10,
+          "tempo": 120,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        }
+      ],
+      "effects": {}
+    },
+    {
+      "clips": [
+        {
+          "filekey": "RD_POP_SYNTHBASS_6",
+          "track": 2,
+          "measure": 1,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 11,
+          "tempo": 120,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "RD_POP_SYNTHBASS_6",
+          "track": 2,
+          "measure": 5,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 11,
+          "tempo": 120,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": true
+        }
+      ],
+      "effects": {
+        "VOLUME": {
+          "GAIN": [
+            {
+              "measure": 1,
+              "value": -20,
+              "shape": "linear",
+              "sourceLine": 18
+            },
+            {
+              "measure": 5,
+              "value": 6,
+              "shape": "square",
+              "sourceLine": 18
+            }
+          ]
+        }
+      }
+    },
+    {
+      "clips": [
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.25,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.375,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.5,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.5625,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.75,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.8125,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.875,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "OS_SNARE03",
+          "track": 3,
+          "measure": 4.9375,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 24,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8.1875,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8.375,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8.5625,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8.75,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "Y09_KICK_1",
+          "track": 3,
+          "measure": 8.875,
+          "start": 1,
+          "end": 1.0625,
+          "scale": false,
+          "loop": false,
+          "silence": 0.0625,
+          "sourceLine": 25,
+          "tempo": 91,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        }
+      ],
+      "effects": {}
+    },
+    {
+      "clips": [
+        {
+          "filekey": "YG_RNB_TAMBOURINE_1",
+          "track": 4,
+          "measure": 1,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 12,
+          "tempo": 96,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        },
+        {
+          "filekey": "YG_RNB_TAMBOURINE_1",
+          "track": 4,
+          "measure": 5,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 12,
+          "tempo": 96,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": true
+        }
+      ],
+      "effects": {}
+    },
+    {
+      "clips": [
+        {
+          "filekey": "YG_FUNK_CONGAS_3",
+          "track": 5,
+          "measure": 1,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 13,
+          "tempo": 105,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        }
+      ],
+      "effects": {}
+    },
+    {
+      "clips": [
+        {
+          "filekey": "YG_FUNK_HIHAT_2",
+          "track": 6,
+          "measure": 5,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 14,
+          "tempo": 100,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        }
+      ],
+      "effects": {}
+    },
+    {
+      "clips": [
+        {
+          "filekey": "RD_POP_TB303LEAD_3",
+          "track": 7,
+          "measure": 5,
+          "start": 1,
+          "end": 5,
+          "scale": false,
+          "loop": true,
+          "silence": 0,
+          "sourceLine": 15,
+          "tempo": 120,
+          "sourceAudio": {},
+          "audio": {},
+          "loopChild": false
+        }
+      ],
+      "effects": {}
+    }
+  ],
+  "transformedClips": {}
+}

--- a/tests/vitest/src/daw/dawDiffs.spec.ts
+++ b/tests/vitest/src/daw/dawDiffs.spec.ts
@@ -9,6 +9,7 @@ import baselineMinusEffect from "../../fixtures/dawDiffScripts/baseline-minus-1-
 import baselineAddEffectEnvPoint from "../../fixtures/dawDiffScripts/baseline-add-effect-env-point.json"
 import baselineAddEffectEnvPoints from "../../fixtures/dawDiffScripts/baseline-add-effect-env-points.json"
 import baselineChangedEffectEnvPointValue from "../../fixtures/dawDiffScripts/baseline-changed-effect-env-point-value.json"
+import baselineChangedSound from "../../fixtures/dawDiffScripts/baseline-change-sound.json"
 
 import type { DAWData } from "../../../../src/types/common"
 
@@ -202,6 +203,22 @@ describe("getDAWDataDifferences", () => {
         const differences = getDAWDataDifferences(baseline, baselineChangedEffectEnvPointValue)
         expectDifferences(differences, [
             { key: "trackEffectEnvelopeChanged", params: { trackNum: 2, effect: "VOLUME", effectParam: "GAIN" } },
+        ])
+    })
+
+    it("detects sound adds and removes from a single track", () => {
+        const differences = getDAWDataDifferences(baseline, baselineChangedSound)
+        expectDifferences(differences, [
+            {
+                key: "trackClipsChanged",
+                params: {
+                    trackNum: 1,
+                    addedText: "{\"key\":\"messages:idecontroller.clipFilesAdded\",\"params\":{\"filekeys\":\"RD_POP_SYNTHBASS_6\"}}",
+                    removedText: "{\"key\":\"messages:idecontroller.clipFilesRemoved\",\"params\":{\"filekeys\":\"RD_UK_HOUSE_MAINBEAT_8\"}}",
+                    spanStart: 1,
+                    spanEnd: 5,
+                },
+            },
         ])
     })
 


### PR DESCRIPTION
One of the diff strings contained a placeholder (measures) which was displayed to the user because it wasn't populated. This was leftover from when this feature used to calculate the number of measured that had changed in a track and is no longer used.

This PR removes the placeholder and adds a test for this i18n key as it wasn't covered by a dawDiff test.