### PR TITLE
Throttle notifications polling interval

### DIFF
--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -44,7 +44,6 @@ export const NotificationBar = () => {
 
 const popupQueue: Message[] = []
 let popupTimeout = 0
-const NOTIFICATION_POLL_INTERVALS_MS = [5, 10, 30, 60].map(minutes => minutes * 60 * 1000)
 
 export const NotificationPopup = () => {
     const [message, setMessage] = useState(null as Message | null)
@@ -102,6 +101,8 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 60].map(minutes => minutes * 60 * 1000)
+
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
@@ -130,9 +131,9 @@ const useNotificationLongPolling = () => {
         }
 
         const scheduleNextPoll = () => {
-            if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
+            if (!isPolling || timeoutId != null) return
 
-            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[Math.min(intervalIndex, NOTIFICATION_POLL_INTERVALS_MS.length - 1)]
             timeoutId = window.setTimeout(async () => {
                 timeoutId = null
                 intervalIndex += 1

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -168,10 +168,8 @@ const useNotificationLongPolling = () => {
         // Only poll when the page is visible to avoid unnecessary requests
         const onVisibilityChange = () => {
             if (document.visibilityState === "visible") {
-                console.log("Visibility change: Start notification polling", new Date().toLocaleTimeString())
                 startPolling()
             } else {
-                console.log("Visibility change: Stop notification polling", new Date().toLocaleTimeString())
                 stopPolling()
             }
         }

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -121,6 +121,7 @@ const useNotificationLongPolling = () => {
         let timeoutId: number | null = null
         let intervalIndex = 0
         let isPolling = false
+        let hasFetchedInitialNotifications = false
 
         const clearScheduledPoll = () => {
             if (timeoutId == null) return
@@ -132,9 +133,9 @@ const useNotificationLongPolling = () => {
             if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
 
             const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
-            intervalIndex += 1
             timeoutId = window.setTimeout(async () => {
                 timeoutId = null
+                intervalIndex += 1
                 await fetchNotifications()
                 scheduleNextPoll()
             }, interval)
@@ -143,8 +144,10 @@ const useNotificationLongPolling = () => {
         const startPolling = () => {
             if (isPolling) return
             isPolling = true
-            intervalIndex = 0
-            fetchNotifications()
+            if (!hasFetchedInitialNotifications) {
+                hasFetchedInitialNotifications = true
+                fetchNotifications()
+            }
             scheduleNextPoll()
         }
 

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -101,28 +101,35 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
-    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 60].map(minutes => minutes * 60 * 1000)
+    // Polling interval sequence, repeating the final value forever
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60].map(minutes => minutes * 60 * 1000)
 
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
         if (!isLoggedIn) return
 
+        let timeoutId: number | null = null
+        let intervalIndex = 0
+        let isPolling = false
+        let hasFetchedInitialNotifications = false
+        let latestNotificationCount: number | null = null
+
         const fetchNotifications = async () => {
             try {
                 const result = await request.getAuth("/users/notifications")
                 if (Array.isArray(result)) {
+                    // Reset to the shortest polling interval if we detect new notifications
+                    if (latestNotificationCount !== null && result.length > latestNotificationCount) {
+                        intervalIndex = 0
+                    }
+                    latestNotificationCount = result.length
                     userNotification.loadHistory(result)
                 }
             } catch (error) {
                 console.error("Error fetching notifications:", error)
             }
         }
-
-        let timeoutId: number | null = null
-        let intervalIndex = 0
-        let isPolling = false
-        let hasFetchedInitialNotifications = false
 
         const clearScheduledPoll = () => {
             if (timeoutId == null) return
@@ -142,6 +149,7 @@ const useNotificationLongPolling = () => {
             }, interval)
         }
 
+        // Immediately fetch on page load, then schedule the next poll
         const startPolling = () => {
             if (isPolling) return
             isPolling = true
@@ -157,6 +165,7 @@ const useNotificationLongPolling = () => {
             clearScheduledPoll()
         }
 
+        // Only poll when the page is visible to avoid unnecessary requests
         const onVisibilityChange = () => {
             if (document.visibilityState === "visible") {
                 console.log("Visibility change: Start notification polling", new Date().toLocaleTimeString())

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -44,6 +44,7 @@ export const NotificationBar = () => {
 
 const popupQueue: Message[] = []
 let popupTimeout = 0
+const NOTIFICATION_POLL_INTERVALS_MS = [5, 10, 30, 60].map(minutes => minutes * 60 * 1000)
 
 export const NotificationPopup = () => {
     const [message, setMessage] = useState(null as Message | null)
@@ -101,8 +102,6 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
-    const FETCH_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
-
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
@@ -119,18 +118,39 @@ const useNotificationLongPolling = () => {
             }
         }
 
-        let intervalId: number | null = null
+        let timeoutId: number | null = null
+        let intervalIndex = 0
+        let isPolling = false
+
+        const clearScheduledPoll = () => {
+            if (timeoutId == null) return
+            window.clearTimeout(timeoutId)
+            timeoutId = null
+        }
+
+        const scheduleNextPoll = () => {
+            if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
+
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
+            intervalIndex += 1
+            timeoutId = window.setTimeout(async () => {
+                timeoutId = null
+                await fetchNotifications()
+                scheduleNextPoll()
+            }, interval)
+        }
 
         const startPolling = () => {
-            if (intervalId != null) return
+            if (isPolling) return
+            isPolling = true
+            intervalIndex = 0
             fetchNotifications()
-            intervalId = window.setInterval(fetchNotifications, FETCH_INTERVAL_MS)
+            scheduleNextPoll()
         }
 
         const stopPolling = () => {
-            if (intervalId == null) return
-            window.clearInterval(intervalId)
-            intervalId = null
+            isPolling = false
+            clearScheduledPoll()
         }
 
         const onVisibilityChange = () => {

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -169,10 +169,8 @@ const useNotificationLongPolling = () => {
         // Only poll when the page is visible to avoid unnecessary requests
         const onVisibilityChange = () => {
             if (document.visibilityState === "visible") {
-                console.log("Visibility change: Start notification polling", new Date().toLocaleTimeString())
                 startPolling()
             } else {
-                console.log("Visibility change: Stop notification polling", new Date().toLocaleTimeString())
                 stopPolling()
             }
         }

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react"
+import React, { useRef, useState } from "react"
 import { Popover } from "@headlessui/react"
 import { useSelector } from "react-redux"
 
@@ -7,8 +7,8 @@ import * as userNotification from "./notification"
 import * as user from "./userState"
 import { useTranslation } from "react-i18next"
 import * as appState from "../app/appState"
-import * as request from "../request"
 import broadcastIcon from "./broadcast.svg"
+import { useNotificationLongPolling } from "./useNotificationLongPolling"
 
 interface Message {
     text: string
@@ -98,97 +98,6 @@ export const NotificationPopup = () => {
             }}>X</span>
         </div>
     </div>
-}
-
-/** Automatically fetch notifications every X minutes when logged in */
-const useNotificationLongPolling = () => {
-    // Polling interval sequence, stopping after the final interval
-    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60, 60].map(min => min * 60 * 1000)
-
-    const isLoggedIn = useSelector(user.selectLoggedIn)
-
-    useEffect(() => {
-        if (!isLoggedIn) return
-
-        let timeoutId: number | null = null
-        let intervalIndex = 0
-        let isPolling = false
-        let hasFetchedInitialNotifications = false
-        let latestNotificationCount: number | null = null
-
-        const fetchNotifications = async () => {
-            try {
-                const result = await request.getAuth("/users/notifications")
-                if (Array.isArray(result)) {
-                    // Reset to the shortest polling interval if we detect new notifications
-                    if (latestNotificationCount !== null && result.length > latestNotificationCount) {
-                        intervalIndex = 0
-                    }
-                    latestNotificationCount = result.length
-                    userNotification.loadHistory(result)
-                }
-            } catch (error) {
-                console.error("Error fetching notifications:", error)
-            }
-        }
-
-        const clearScheduledPoll = () => {
-            if (timeoutId == null) return
-            window.clearTimeout(timeoutId)
-            timeoutId = null
-        }
-
-        const scheduleNextPoll = () => {
-            if (!isPolling || timeoutId != null) return
-            if (intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) {
-                isPolling = false
-                return
-            }
-
-            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
-            timeoutId = window.setTimeout(async () => {
-                timeoutId = null
-                intervalIndex += 1
-                await fetchNotifications()
-                scheduleNextPoll()
-            }, interval)
-        }
-
-        // Immediately fetch on page load, then schedule the next poll
-        const startPolling = () => {
-            if (isPolling) return
-            isPolling = true
-            if (!hasFetchedInitialNotifications) {
-                hasFetchedInitialNotifications = true
-                fetchNotifications()
-            }
-            scheduleNextPoll()
-        }
-
-        const stopPolling = () => {
-            isPolling = false
-            clearScheduledPoll()
-        }
-
-        // Only poll when the page is visible to avoid unnecessary requests
-        const onVisibilityChange = () => {
-            if (document.visibilityState === "visible") {
-                startPolling()
-            } else {
-                stopPolling()
-            }
-        }
-
-        // start based on initial visibility
-        onVisibilityChange()
-
-        document.addEventListener("visibilitychange", onVisibilityChange)
-
-        return () => {
-            stopPolling()
-            document.removeEventListener("visibilitychange", onVisibilityChange)
-        }
-    }, [isLoggedIn])
 }
 
 /** Small blue bullhorn indicator used for broadcast announcements. */

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -102,8 +102,8 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
-    // Polling interval sequence, repeating the final value forever
-    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60].map(minutes => minutes * 60 * 1000)
+    // Polling interval sequence, stopping after the final interval
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60, 60].map(min => min * 60 * 1000)
 
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
@@ -140,8 +140,12 @@ const useNotificationLongPolling = () => {
 
         const scheduleNextPoll = () => {
             if (!isPolling || timeoutId != null) return
+            if (intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) {
+                isPolling = false
+                return
+            }
 
-            const interval = NOTIFICATION_POLL_INTERVALS_MS[Math.min(intervalIndex, NOTIFICATION_POLL_INTERVALS_MS.length - 1)]
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
             timeoutId = window.setTimeout(async () => {
                 timeoutId = null
                 intervalIndex += 1

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -45,6 +45,7 @@ export const NotificationBar = () => {
 
 const popupQueue: Message[] = []
 let popupTimeout = 0
+const NOTIFICATION_POLL_INTERVALS_MS = [5, 10, 30, 60].map(minutes => minutes * 60 * 1000)
 
 export const NotificationPopup = () => {
     const [message, setMessage] = useState(null as Message | null)
@@ -102,8 +103,6 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
-    const FETCH_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
-
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
@@ -120,18 +119,39 @@ const useNotificationLongPolling = () => {
             }
         }
 
-        let intervalId: number | null = null
+        let timeoutId: number | null = null
+        let intervalIndex = 0
+        let isPolling = false
+
+        const clearScheduledPoll = () => {
+            if (timeoutId == null) return
+            window.clearTimeout(timeoutId)
+            timeoutId = null
+        }
+
+        const scheduleNextPoll = () => {
+            if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
+
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
+            intervalIndex += 1
+            timeoutId = window.setTimeout(async () => {
+                timeoutId = null
+                await fetchNotifications()
+                scheduleNextPoll()
+            }, interval)
+        }
 
         const startPolling = () => {
-            if (intervalId != null) return
+            if (isPolling) return
+            isPolling = true
+            intervalIndex = 0
             fetchNotifications()
-            intervalId = window.setInterval(fetchNotifications, FETCH_INTERVAL_MS)
+            scheduleNextPoll()
         }
 
         const stopPolling = () => {
-            if (intervalId == null) return
-            window.clearInterval(intervalId)
-            intervalId = null
+            isPolling = false
+            clearScheduledPoll()
         }
 
         const onVisibilityChange = () => {

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -217,7 +217,7 @@ export const NotificationList = ({ openSharedScript, showHistory, close }: {
 
         // Fetch the latest notifications and immediately update the state
         try {
-            const result = await request.getAuth("/users/notifications")
+            const result = await getAuth("/users/notifications")
             if (result && Array.isArray(result)) {
                 userNotification.loadHistory(result)
             }

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -45,7 +45,6 @@ export const NotificationBar = () => {
 
 const popupQueue: Message[] = []
 let popupTimeout = 0
-const NOTIFICATION_POLL_INTERVALS_MS = [5, 10, 30, 60].map(minutes => minutes * 60 * 1000)
 
 export const NotificationPopup = () => {
     const [message, setMessage] = useState(null as Message | null)
@@ -103,6 +102,8 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 60].map(minutes => minutes * 60 * 1000)
+
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
@@ -131,9 +132,9 @@ const useNotificationLongPolling = () => {
         }
 
         const scheduleNextPoll = () => {
-            if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
+            if (!isPolling || timeoutId != null) return
 
-            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[Math.min(intervalIndex, NOTIFICATION_POLL_INTERVALS_MS.length - 1)]
             timeoutId = window.setTimeout(async () => {
                 timeoutId = null
                 intervalIndex += 1

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -102,28 +102,35 @@ export const NotificationPopup = () => {
 
 /** Automatically fetch notifications every X minutes when logged in */
 const useNotificationLongPolling = () => {
-    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 60].map(minutes => minutes * 60 * 1000)
+    // Polling interval sequence, repeating the final value forever
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60].map(minutes => minutes * 60 * 1000)
 
     const isLoggedIn = useSelector(user.selectLoggedIn)
 
     useEffect(() => {
         if (!isLoggedIn) return
 
+        let timeoutId: number | null = null
+        let intervalIndex = 0
+        let isPolling = false
+        let hasFetchedInitialNotifications = false
+        let latestNotificationCount: number | null = null
+
         const fetchNotifications = async () => {
             try {
                 const result = await request.getAuth("/users/notifications")
                 if (Array.isArray(result)) {
+                    // Reset to the shortest polling interval if we detect new notifications
+                    if (latestNotificationCount !== null && result.length > latestNotificationCount) {
+                        intervalIndex = 0
+                    }
+                    latestNotificationCount = result.length
                     userNotification.loadHistory(result)
                 }
             } catch (error) {
                 console.error("Error fetching notifications:", error)
             }
         }
-
-        let timeoutId: number | null = null
-        let intervalIndex = 0
-        let isPolling = false
-        let hasFetchedInitialNotifications = false
 
         const clearScheduledPoll = () => {
             if (timeoutId == null) return
@@ -143,6 +150,7 @@ const useNotificationLongPolling = () => {
             }, interval)
         }
 
+        // Immediately fetch on page load, then schedule the next poll
         const startPolling = () => {
             if (isPolling) return
             isPolling = true
@@ -158,6 +166,7 @@ const useNotificationLongPolling = () => {
             clearScheduledPoll()
         }
 
+        // Only poll when the page is visible to avoid unnecessary requests
         const onVisibilityChange = () => {
             if (document.visibilityState === "visible") {
                 console.log("Visibility change: Start notification polling", new Date().toLocaleTimeString())

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -122,6 +122,7 @@ const useNotificationLongPolling = () => {
         let timeoutId: number | null = null
         let intervalIndex = 0
         let isPolling = false
+        let hasFetchedInitialNotifications = false
 
         const clearScheduledPoll = () => {
             if (timeoutId == null) return
@@ -133,9 +134,9 @@ const useNotificationLongPolling = () => {
             if (!isPolling || timeoutId != null || intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) return
 
             const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
-            intervalIndex += 1
             timeoutId = window.setTimeout(async () => {
                 timeoutId = null
+                intervalIndex += 1
                 await fetchNotifications()
                 scheduleNextPoll()
             }, interval)
@@ -144,8 +145,10 @@ const useNotificationLongPolling = () => {
         const startPolling = () => {
             if (isPolling) return
             isPolling = true
-            intervalIndex = 0
-            fetchNotifications()
+            if (!hasFetchedInitialNotifications) {
+                hasFetchedInitialNotifications = true
+                fetchNotifications()
+            }
             scheduleNextPoll()
         }
 

--- a/src/user/Notifications.tsx
+++ b/src/user/Notifications.tsx
@@ -1,14 +1,15 @@
 import React, { useRef, useState } from "react"
-import { Popover } from "@headlessui/react"
 import { useSelector } from "react-redux"
+import { Popover } from "@headlessui/react"
 
-import * as ESUtils from "../esutils"
-import * as userNotification from "./notification"
-import * as user from "./userState"
 import { useTranslation } from "react-i18next"
 import * as appState from "../app/appState"
+import * as ESUtils from "../esutils"
+import { getAuth } from "../request"
 import broadcastIcon from "./broadcast.svg"
+import * as userNotification from "./notification"
 import { useNotificationLongPolling } from "./useNotificationLongPolling"
+import * as user from "./userState"
 
 interface Message {
     text: string

--- a/src/user/useNotificationLongPolling.ts
+++ b/src/user/useNotificationLongPolling.ts
@@ -1,0 +1,97 @@
+import { useEffect } from "react"
+import { useSelector } from "react-redux"
+
+import * as request from "../request"
+import * as userNotification from "./notification"
+import * as user from "./userState"
+
+/** Automatically fetch notifications every X minutes when logged in */
+export const useNotificationLongPolling = () => {
+    // Polling interval sequence, stopping after the final interval
+    const NOTIFICATION_POLL_INTERVALS_MS = [5, 5, 5, 30, 60, 60].map(min => min * 60 * 1000)
+
+    const isLoggedIn = useSelector(user.selectLoggedIn)
+
+    useEffect(() => {
+        if (!isLoggedIn) return
+
+        let timeoutId: number | null = null
+        let intervalIndex = 0
+        let isPolling = false
+        let hasFetchedInitialNotifications = false
+        let latestNotificationCount: number | null = null
+
+        const fetchNotifications = async () => {
+            try {
+                const result = await request.getAuth("/users/notifications")
+                if (Array.isArray(result)) {
+                    // Reset to the shortest polling interval if we detect new notifications
+                    if (latestNotificationCount !== null && result.length > latestNotificationCount) {
+                        intervalIndex = 0
+                    }
+                    latestNotificationCount = result.length
+                    userNotification.loadHistory(result)
+                }
+            } catch (error) {
+                console.error("Error fetching notifications:", error)
+            }
+        }
+
+        const clearScheduledPoll = () => {
+            if (timeoutId == null) return
+            window.clearTimeout(timeoutId)
+            timeoutId = null
+        }
+
+        const scheduleNextPoll = () => {
+            if (!isPolling || timeoutId != null) return
+            if (intervalIndex >= NOTIFICATION_POLL_INTERVALS_MS.length) {
+                isPolling = false
+                return
+            }
+
+            const interval = NOTIFICATION_POLL_INTERVALS_MS[intervalIndex]
+            timeoutId = window.setTimeout(async () => {
+                timeoutId = null
+                intervalIndex += 1
+                await fetchNotifications()
+                scheduleNextPoll()
+            }, interval)
+        }
+
+        // Immediately fetch on page load, then schedule the next poll
+        const startPolling = () => {
+            if (isPolling) return
+            isPolling = true
+            if (!hasFetchedInitialNotifications) {
+                hasFetchedInitialNotifications = true
+                fetchNotifications()
+            }
+            scheduleNextPoll()
+        }
+
+        const stopPolling = () => {
+            isPolling = false
+            clearScheduledPoll()
+        }
+
+        // Only poll when the page is visible to avoid unnecessary requests
+        const onVisibilityChange = () => {
+            if (document.visibilityState === "visible") {
+                startPolling()
+            } else {
+                stopPolling()
+            }
+        }
+
+        // start based on initial visibility
+        onVisibilityChange()
+
+        document.addEventListener("visibilitychange", onVisibilityChange)
+
+        return () => {
+            stopPolling()
+            document.removeEventListener("visibilitychange", onVisibilityChange)
+        }
+    }, [isLoggedIn])
+}

--- a/src/user/useNotificationLongPolling.ts
+++ b/src/user/useNotificationLongPolling.ts
@@ -84,7 +84,7 @@ export const useNotificationLongPolling = () => {
             }
         }
 
-        // start based on initial visibility
+        // Start based on initial visibility
         onVisibilityChange()
 
         document.addEventListener("visibilitychange", onVisibilityChange)

--- a/src/user/useNotificationLongPolling.ts
+++ b/src/user/useNotificationLongPolling.ts
@@ -18,12 +18,14 @@ export const useNotificationLongPolling = () => {
         let timeoutId: number | null = null
         let intervalIndex = 0
         let isPolling = false
+        let didCancel = false
         let hasFetchedInitialNotifications = false
         let latestNotificationCount: number | null = null
 
         const fetchNotifications = async () => {
             try {
                 const result = await request.getAuth("/users/notifications")
+                if (didCancel) return
                 if (Array.isArray(result)) {
                     // Reset to the shortest polling interval if we detect new notifications
                     if (latestNotificationCount !== null && result.length > latestNotificationCount) {
@@ -90,6 +92,7 @@ export const useNotificationLongPolling = () => {
         document.addEventListener("visibilitychange", onVisibilityChange)
 
         return () => {
+            didCancel = true // Handle mid-fetch logout - or any unmount
             stopPolling()
             document.removeEventListener("visibilitychange", onVisibilityChange)
         }


### PR DESCRIPTION
Throttles the polling slower and slower, stopping after 3 hours, resetting if a notification is received.

Relates to GTCMT/earsketch#3658.