### PR TITLE
Added Radix tooltips to sound browser

### DIFF
--- a/src/browser/Sounds.tsx
+++ b/src/browser/Sounds.tsx
@@ -469,22 +469,24 @@ const Clip = React.memo(({ clip, bgcolor, borderColor, previewState, loggedIn, i
             <div className="h-auto border-l-8 border-blue-300" />
             <div className={`flex grow truncate justify-between py-0.5 ${bgcolor} border ${borderColor}`}>
                 <div className="flex items-center min-w-0">
-                    <Tooltip.Root>
-                        <Tooltip.Trigger asChild>
-                            <h5 className="scale:text-sm truncate pl-2 cursor-default">{name}</h5>
-                        </Tooltip.Trigger>
-                        <Tooltip.Portal>
-                            <Tooltip.Content
-                                side="top"
-                                align="start"
-                                sideOffset={4}
-                                style={{ fontSize: `${scaledFontSize}px` }}
-                                className="scale:text-xs z-50 rounded bg-gray-800 px-3 py-2 text-white shadow-lg pointer-events-none"
-                            >
-                                {tooltipContent}
-                            </Tooltip.Content>
-                        </Tooltip.Portal>
-                    </Tooltip.Root>
+                    <Tooltip.Provider delayDuration={600} disableHoverableContent>
+                        <Tooltip.Root>
+                            <Tooltip.Trigger asChild>
+                                <h5 className="scale:text-sm truncate pl-2 cursor-default">{name}</h5>
+                            </Tooltip.Trigger>
+                            <Tooltip.Portal>
+                                <Tooltip.Content
+                                    side="top"
+                                    align="start"
+                                    sideOffset={4}
+                                    style={{ fontSize: `${scaledFontSize}px` }}
+                                    className="scale:text-xs z-50 rounded bg-gray-800 px-3 py-2 text-white shadow-lg pointer-events-none"
+                                >
+                                    {tooltipContent}
+                                </Tooltip.Content>
+                            </Tooltip.Portal>
+                        </Tooltip.Root>
+                    </Tooltip.Provider>
                 </div>
                 <div className="pl-2 pr-4">
                     <button

--- a/src/browser/Sounds.tsx
+++ b/src/browser/Sounds.tsx
@@ -15,6 +15,7 @@ import * as tabs from "../ide/tabState"
 import type { RootState } from "../reducers"
 import type { SoundEntity } from "common"
 import { BrowserTabType } from "./BrowserTab"
+import * as Tooltip from "@radix-ui/react-tooltip"
 
 import { SearchBar } from "./Utils"
 
@@ -448,25 +449,42 @@ const Clip = React.memo(({ clip, bgcolor, borderColor, previewState, loggedIn, i
     const dispatch = useDispatch()
     const { t } = useTranslation()
     const name = clip.name
+    const scaledFontSize = useSelector(appState.selectScaledFontSize)
 
-    let tooltip = `${t("soundBrowser.clip.tooltip.file")}: ${name}
-    ${t("soundBrowser.clip.tooltip.folder")}: ${clip.folder}
-    ${t("soundBrowser.clip.tooltip.artist")}: ${clip.artist}
-    ${t("soundBrowser.clip.tooltip.genre")}: ${clip.genre}
-    ${t("soundBrowser.clip.tooltip.instrument")}: ${clip.instrument}
-    ${t("soundBrowser.clip.tooltip.originalTempo")}: ${clip.tempo}
-    ${t("soundBrowser.clip.tooltip.year")}: ${clip.year}`.replace(/\n\s+/g, "\n")
-
-    if (clip.keySignature) {
-        tooltip = tooltip.concat("\n", t("soundBrowser.clip.tooltip.key"), ": ", clip.keySignature)
-    }
+    const tooltipContent = (
+        <div>
+            <div>{t("soundBrowser.clip.tooltip.file")}: {name}</div>
+            <div>{t("soundBrowser.clip.tooltip.folder")}: {clip.folder}</div>
+            <div>{t("soundBrowser.clip.tooltip.artist")}: {clip.artist}</div>
+            <div>{t("soundBrowser.clip.tooltip.genre")}: {clip.genre}</div>
+            <div>{t("soundBrowser.clip.tooltip.instrument")}: {clip.instrument}</div>
+            <div>{t("soundBrowser.clip.tooltip.originalTempo")}: {clip.tempo}</div>
+            <div>{t("soundBrowser.clip.tooltip.year")}: {clip.year}</div>
+            {clip.keySignature && <div>{t("soundBrowser.clip.tooltip.key")}: {clip.keySignature}</div>}
+        </div>
+    )
 
     return (
         <div className="flex flex-row justify-start">
             <div className="h-auto border-l-8 border-blue-300" />
             <div className={`flex grow truncate justify-between py-0.5 ${bgcolor} border ${borderColor}`}>
-                <div className="flex items-center min-w-0" title={tooltip}>
-                    <h5 className="scale:text-sm truncate pl-2">{name}</h5>
+                <div className="flex items-center min-w-0">
+                    <Tooltip.Root>
+                        <Tooltip.Trigger asChild>
+                            <h5 className="scale:text-sm truncate pl-2 cursor-default">{name}</h5>
+                        </Tooltip.Trigger>
+                        <Tooltip.Portal>
+                            <Tooltip.Content
+                                side="top"
+                                align="start"
+                                sideOffset={4}
+                                style={{ fontSize: `${scaledFontSize}px`}}
+                                className="scale:text-xs z-50 rounded bg-gray-800 px-3 py-2 text-white shadow-lg pointer-events-none"
+                            >
+                                {tooltipContent}
+                            </Tooltip.Content>
+                        </Tooltip.Portal>
+                    </Tooltip.Root>
                 </div>
                 <div className="pl-2 pr-4">
                     <button

--- a/src/browser/Sounds.tsx
+++ b/src/browser/Sounds.tsx
@@ -478,7 +478,7 @@ const Clip = React.memo(({ clip, bgcolor, borderColor, previewState, loggedIn, i
                                 side="top"
                                 align="start"
                                 sideOffset={4}
-                                style={{ fontSize: `${scaledFontSize}px`}}
+                                style={{ fontSize: `${scaledFontSize}px` }}
                                 className="scale:text-xs z-50 rounded bg-gray-800 px-3 py-2 text-white shadow-lg pointer-events-none"
                             >
                                 {tooltipContent}

--- a/src/ide/IDE.tsx
+++ b/src/ide/IDE.tsx
@@ -42,7 +42,6 @@ import * as user from "../user/userState"
 import type { DAWData } from "common"
 import classNames from "classnames"
 import { cloneDAWDataForComparison, getDAWDataDifferences } from "./dawDataDescriptions"
-import * as Tooltip from "@radix-ui/react-tooltip"
 
 const STATUS_SUCCESSFUL = 1
 const STATUS_UNSUCCESSFUL = 2
@@ -430,9 +429,7 @@ export const IDE = ({ closeAllTabs, importScript, shareScript, downloadScript }:
             >
                 <div id="sidebar-container" style={bubbleActive && [5, 6, 7, 9].includes(bubblePage) ? { zIndex: 35 } : {}}>
                     <div className="overflow-hidden" id="sidebar"> {/* re:overflow, split.js width calculation can cause the width to spill over the parent width */}
-                        <Tooltip.Provider delayDuration={600} disableHoverableContent>
-                            <Browser />
-                        </Tooltip.Provider>
+                        <Browser />
                     </div>
                 </div>
 

--- a/src/ide/IDE.tsx
+++ b/src/ide/IDE.tsx
@@ -42,6 +42,7 @@ import * as user from "../user/userState"
 import type { DAWData } from "common"
 import classNames from "classnames"
 import { cloneDAWDataForComparison, getDAWDataDifferences } from "./dawDataDescriptions"
+import * as Tooltip from "@radix-ui/react-tooltip"
 
 const STATUS_SUCCESSFUL = 1
 const STATUS_UNSUCCESSFUL = 2
@@ -429,7 +430,9 @@ export const IDE = ({ closeAllTabs, importScript, shareScript, downloadScript }:
             >
                 <div id="sidebar-container" style={bubbleActive && [5, 6, 7, 9].includes(bubblePage) ? { zIndex: 35 } : {}}>
                     <div className="overflow-hidden" id="sidebar"> {/* re:overflow, split.js width calculation can cause the width to spill over the parent width */}
-                        <Browser />
+                        <Tooltip.Provider delayDuration={600} disableHoverableContent>
+                            <Browser />
+                        </Tooltip.Provider>
                     </div>
                 </div>
 


### PR DESCRIPTION
Tooltips use same scaling method, limited to sound info and not play/paste/favorite buttons for consistency. 