### PR TITLE
Provide default sliceStarts for makeBeatSlice

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -28,7 +28,7 @@ export const API_FUNCTIONS = {
     reverseString: { async: false, mod: false, return: true },
     shuffleList: { async: false, mod: false, return: true },
     shuffleString: { async: false, mod: false, return: true },
-    sliceInto: { async: false, mod: false, return: true },
+    sliceEveryNth: { async: false, mod: false, return: true },
     // Both return a value and modify DAW data.
     createAudioSlice: { async: false, mod: true, return: true },
     createAudioStretch: { async: false, mod: true, return: true },
@@ -374,9 +374,9 @@ const rawDoc: { [key: string]: Item[] } = {
         },
         returns: "string",
     }],
-    sliceInto: [{
+    sliceEveryNth: [{
         parameters: {
-            nSlices: "integer",
+            n: "float",
         },
         returns: "listArray",
     }],

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -28,6 +28,7 @@ export const API_FUNCTIONS = {
     reverseString: { async: false, mod: false, return: true },
     shuffleList: { async: false, mod: false, return: true },
     shuffleString: { async: false, mod: false, return: true },
+    sliceInto: { async: false, mod: false, return: true },
     // Both return a value and modify DAW data.
     createAudioSlice: { async: false, mod: true, return: true },
     createAudioStretch: { async: false, mod: true, return: true },
@@ -239,6 +240,14 @@ const rawDoc: { [key: string]: Item[] } = {
                 default: "16",
             },
         },
+    },
+    {
+        parameters: {
+            sound: "soundConstant",
+            track: "integer",
+            start: "float",
+            beat: "string",
+        },
     }],
     print: [{
         parameters: {
@@ -364,6 +373,12 @@ const rawDoc: { [key: string]: Item[] } = {
             string: "string",
         },
         returns: "string",
+    }],
+    sliceInto: [{
+        parameters: {
+            nSlices: "integer",
+        },
+        returns: "listArray",
     }],
 }
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -225,6 +225,14 @@ const rawDoc: { [key: string]: Item[] } = {
             track: "integer",
             start: "float",
             beat: "string",
+        },
+    },
+    {
+        parameters: {
+            sound: "soundConstant",
+            track: "integer",
+            start: "float",
+            beat: "string",
             sliceStarts: "listArray",
         },
     },
@@ -239,14 +247,6 @@ const rawDoc: { [key: string]: Item[] } = {
                 type: "floatOptional",
                 default: "16",
             },
-        },
-    },
-    {
-        parameters: {
-            sound: "soundConstant",
-            track: "integer",
-            start: "float",
-            beat: "string",
         },
     }],
     print: [{

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -28,7 +28,7 @@ export const API_FUNCTIONS = {
     reverseString: { async: false, mod: false, return: true },
     shuffleList: { async: false, mod: false, return: true },
     shuffleString: { async: false, mod: false, return: true },
-    sliceEveryNth: { async: false, mod: false, return: true },
+    slicesPerMeasure: { async: false, mod: false, return: true },
     // Both return a value and modify DAW data.
     createAudioSlice: { async: false, mod: true, return: true },
     createAudioStretch: { async: false, mod: true, return: true },
@@ -374,7 +374,7 @@ const rawDoc: { [key: string]: Item[] } = {
         },
         returns: "string",
     }],
-    sliceEveryNth: [{
+    slicesPerMeasure: [{
         parameters: {
             n: "float",
         },

--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -296,7 +296,7 @@ export function sliceInto(_result: DAWData, nSlices: number) {
 
     checkArgCount("sliceInto", args, 1, 1)
     checkType("nSlices", "number", nSlices)
-    
+
     return Array.from({ length: nSlices }, (_, x) => 1 + x / nSlices)
 }
 

--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -289,15 +289,16 @@ export function makeBeat(result: DAWData, soundConstant: string | string[], trac
     return result
 }
 
-// Generate n slice-start positions spaced 1/nSlices of a measure apart
-export function sliceInto(_result: DAWData, nSlices: number) {
+// Generates slice start positions, evenly spaced by note duration (every 16ths, 8ths, ...)
+// Ex: sliceEveryNth(4) -> [1, 1.25, 1.5, 1.75, ...]
+export function sliceEveryNth(_result: DAWData, n: number) {
     const args = [...arguments].slice(1)
-    esconsole("Calling sliceInto with parameters" + args.join(", "), ["debug", "PT"])
+    esconsole("Calling sliceEveryNth with parameters" + args.join(", "), ["debug", "PT"])
 
-    checkArgCount("sliceInto", args, 1, 1)
-    checkType("nSlices", "number", nSlices)
+    checkArgCount("sliceEveryNth", args, 1, 1)
+    checkType("n", "number", n)
 
-    return Array.from({ length: nSlices }, (_, x) => 1 + x / nSlices)
+    return Array.from({ length: n }, (_, x) => 1 + x / n)
 }
 
 // Make a beat from media clip slices.
@@ -310,9 +311,10 @@ export function makeBeatSlice(result: DAWData, soundConstant: string, track: num
     checkType("track", "int", track)
     checkType("start", "number", start)
     checkType("beat", "string", beat)
-    if (!sliceStarts) sliceStarts = sliceInto(result, 16)
-    checkType("sliceStarts", "array", sliceStarts)
     checkType("stepsPerMeasure", "number", stepsPerMeasure)
+
+    if (!sliceStarts) sliceStarts = sliceEveryNth(result, 16)
+    checkType("sliceStarts", "array", sliceStarts)
 
     checkRange("track", track, { min: 1 })
     checkRange("start", start, { min: 1 })

--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -289,16 +289,28 @@ export function makeBeat(result: DAWData, soundConstant: string | string[], trac
     return result
 }
 
+// Generate n slice-start positions spaced 1/nSlices of a measure apart
+export function sliceInto(_result: DAWData, nSlices: number) {
+    const args = [...arguments].slice(1)
+    esconsole("Calling sliceInto with parameters" + args.join(", "), ["debug", "PT"])
+
+    checkArgCount("sliceInto", args, 1, 1)
+    checkType("nSlices", "number", nSlices)
+    
+    return Array.from({ length: nSlices }, (_, x) => 1 + x / nSlices)
+}
+
 // Make a beat from media clip slices.
-export function makeBeatSlice(result: DAWData, soundConstant: string, track: number, start: number, beat: string, sliceStarts: number[], stepsPerMeasure: number = 16) {
+export function makeBeatSlice(result: DAWData, soundConstant: string, track: number, start: number, beat: string, sliceStarts?: number[], stepsPerMeasure: number = 16) {
     const args = [...arguments].slice(1)
     esconsole("Calling makeBeatSlice with parameters" + args.join(", "), ["debug", "PT"])
 
-    checkArgCount("makeBeatSlice", args, 5, 6)
+    checkArgCount("makeBeatSlice", args, 4, 6)
     checkType("sound", "string", soundConstant)
     checkType("track", "int", track)
     checkType("start", "number", start)
     checkType("beat", "string", beat)
+    if (!sliceStarts) sliceStarts = sliceInto(result, 16)
     checkType("sliceStarts", "array", sliceStarts)
     checkType("stepsPerMeasure", "number", stepsPerMeasure)
 

--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -290,15 +290,15 @@ export function makeBeat(result: DAWData, soundConstant: string | string[], trac
 }
 
 // Generates slice start positions, evenly spaced by note duration (every 16ths, 8ths, ...)
-// Ex: sliceEveryNth(4) -> [1, 1.25, 1.5, 1.75, ...]
-export function sliceEveryNth(_result: DAWData, n: number) {
+// Ex: slicesPerMeasure(4) -> [1, 1.25, 1.5, 1.75, ...]
+export function slicesPerMeasure(_result: DAWData, n: number) {
     const args = [...arguments].slice(1)
-    esconsole("Calling sliceEveryNth with parameters" + args.join(", "), ["debug", "PT"])
+    esconsole("Calling slicesPerMeasure with parameters" + args.join(", "), ["debug", "PT"])
 
-    checkArgCount("sliceEveryNth", args, 1, 1)
+    checkArgCount("slicesPerMeasure", args, 1, 1)
     checkType("n", "number", n)
 
-    return Array.from({ length: n }, (_, x) => 1 + x / n)
+    return Array.from({ length: 16 }, (_, x) => 1 + x / n)
 }
 
 // Make a beat from media clip slices.
@@ -313,7 +313,7 @@ export function makeBeatSlice(result: DAWData, soundConstant: string, track: num
     checkType("beat", "string", beat)
     checkType("stepsPerMeasure", "number", stepsPerMeasure)
 
-    if (!sliceStarts) sliceStarts = sliceEveryNth(result, 16)
+    if (!sliceStarts) sliceStarts = slicesPerMeasure(result, 16)
     checkType("sliceStarts", "array", sliceStarts)
 
     checkRange("track", track, { min: 1 })

--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -856,27 +856,6 @@
         },
         "beat": {
           "description": "A string indicating the rhythmic pattern to play. \"0\" through \"9\" and \"A\" through \"F\" plays the sound at the location specified at the corresponding index of the beatNumber list/array for a sixteenth note. \"+\" ties (i.e. continues or sustains) the sound for an additional sixteenth note. \"-\" rests (i.e. creates silence) for a sixteenth note."
-        }
-      },
-      "example": {
-        "python": "# Slice by default sixteenth notes\nsound = HIPHOP_DUSTYGROOVE_006\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\")",
-        "javascript": "// Slice by default sixteenth notes\nvar sound = HIPHOP_DUSTYGROOVE_006;\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\");"
-      }
-    },
-    "makeBeatSlice2": {
-      "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
-      "parameters": {
-        "sound": {
-          "description": "A single sound. Typically this is a constant from the sound browser"
-        },
-        "track": {
-          "description": "Track to place pattern onto"
-        },
-        "start": {
-          "description": "Location within the track to start pattern (e.g. 1 will start at the beginning of measure 1)"
-        },
-        "beat": {
-          "description": "A string indicating the rhythmic pattern to play. \"0\" through \"9\" and \"A\" through \"F\" plays the sound at the location specified at the corresponding index of the beatNumber list/array for a sixteenth note. \"+\" ties (i.e. continues or sustains) the sound for an additional sixteenth note. \"-\" rests (i.e. creates silence) for a sixteenth note."
         },
         "sliceStarts": {
           "description": "A list/array of starting locations within the sound. For example, [1.0, 2.5] creates two time locations at measure 1 and measure 2.5 of the sound that can be referenced in the beat string by \"0\" and \"1\" respectively."
@@ -887,7 +866,7 @@
         "javascript": "// Slice and rearrange by sixteenth notes\nvar s = RD_RNB_MOOGLEAD_10;\nvar slices = [1.0, 1.375, 1.25, 1.5, 2.0, 2.25];\nmakeBeatSlice(s, 1, 1, \"4--04-0-30-10+30\", slices);"
       }
     },
-    "makeBeatSlice3": {
+    "makeBeatSlice2": {
       "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
       "parameters": {
         "sound": {
@@ -912,18 +891,6 @@
       "example": {
         "python": "# Slice and rearrange by eighth notes\nsound = HIPHOP_TRAPHOP_BEAT_002\neighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875]\nbeat = \"01261264\"\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8)",
         "javascript": "// Slice and rearrange by eighth notes\nvar sound = HIPHOP_TRAPHOP_BEAT_002;\nvar eighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875];\nvar beat = \"01261264\";\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8);"
-      }
-    },
-    "sliceEveryNth": {
-      "description": "Generates a list of slice start positions evenly spaced by note duration. For example, sliceEveryNth(16) returns positions spaced by sixteenth notes",
-      "parameters": {
-        "n": {
-          "description": "The number of evenly spaced slices per measure. Use 16 for sixteenth notes, 8 for eighth notes, 4 for quarter notes."
-        }
-      },
-      "example": {
-        "python": "# Slice by eighth notes\nslices = sliceEveryNth(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
-        "javascript": "// Slice by eighth notes\nvar slices = sliceEveryNth(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
       }
     },
     "print": {

--- a/src/locales/ar/common.json
+++ b/src/locales/ar/common.json
@@ -856,6 +856,27 @@
         },
         "beat": {
           "description": "A string indicating the rhythmic pattern to play. \"0\" through \"9\" and \"A\" through \"F\" plays the sound at the location specified at the corresponding index of the beatNumber list/array for a sixteenth note. \"+\" ties (i.e. continues or sustains) the sound for an additional sixteenth note. \"-\" rests (i.e. creates silence) for a sixteenth note."
+        }
+      },
+      "example": {
+        "python": "# Slice by default sixteenth notes\nsound = HIPHOP_DUSTYGROOVE_006\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\")",
+        "javascript": "// Slice by default sixteenth notes\nvar sound = HIPHOP_DUSTYGROOVE_006;\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\");"
+      }
+    },
+    "makeBeatSlice2": {
+      "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
+      "parameters": {
+        "sound": {
+          "description": "A single sound. Typically this is a constant from the sound browser"
+        },
+        "track": {
+          "description": "Track to place pattern onto"
+        },
+        "start": {
+          "description": "Location within the track to start pattern (e.g. 1 will start at the beginning of measure 1)"
+        },
+        "beat": {
+          "description": "A string indicating the rhythmic pattern to play. \"0\" through \"9\" and \"A\" through \"F\" plays the sound at the location specified at the corresponding index of the beatNumber list/array for a sixteenth note. \"+\" ties (i.e. continues or sustains) the sound for an additional sixteenth note. \"-\" rests (i.e. creates silence) for a sixteenth note."
         },
         "sliceStarts": {
           "description": "A list/array of starting locations within the sound. For example, [1.0, 2.5] creates two time locations at measure 1 and measure 2.5 of the sound that can be referenced in the beat string by \"0\" and \"1\" respectively."
@@ -866,7 +887,7 @@
         "javascript": "// Slice and rearrange by sixteenth notes\nvar s = RD_RNB_MOOGLEAD_10;\nvar slices = [1.0, 1.375, 1.25, 1.5, 2.0, 2.25];\nmakeBeatSlice(s, 1, 1, \"4--04-0-30-10+30\", slices);"
       }
     },
-    "makeBeatSlice2": {
+    "makeBeatSlice3": {
       "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
       "parameters": {
         "sound": {
@@ -891,6 +912,18 @@
       "example": {
         "python": "# Slice and rearrange by eighth notes\nsound = HIPHOP_TRAPHOP_BEAT_002\neighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875]\nbeat = \"01261264\"\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8)",
         "javascript": "// Slice and rearrange by eighth notes\nvar sound = HIPHOP_TRAPHOP_BEAT_002;\nvar eighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875];\nvar beat = \"01261264\";\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8);"
+      }
+    },
+    "sliceEveryNth": {
+      "description": "Generates a list of slice start positions evenly spaced by note duration. For example, sliceEveryNth(16) returns positions spaced by sixteenth notes",
+      "parameters": {
+        "n": {
+          "description": "The number of evenly spaced slices per measure. Use 16 for sixteenth notes, 8 for eighth notes, 4 for quarter notes."
+        }
+      },
+      "example": {
+        "python": "# Slice by eighth notes\nslices = sliceEveryNth(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
+        "javascript": "// Slice by eighth notes\nvar slices = sliceEveryNth(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
       }
     },
     "print": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -914,6 +914,28 @@
     },
 
     "makeBeatSlice1": {
+      "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound. Slices default to sixteenth notes.",
+      "parameters": {
+        "sound": {
+          "description": "A single sound. Typically this is a constant from the sound browser"
+        },
+        "track": {
+          "description": "Track to place pattern onto"
+        },
+        "start": {
+          "description": "Location within the track to start pattern (e.g. 1 will start at the beginning of measure 1)"
+        },
+        "beat": {
+          "description": "A string indicating the rhythmic pattern to play. \"0\" through \"9\" and \"A\" through \"F\" plays the sound at the location specified at the corresponding index of the beatNumber list/array for a sixteenth note. \"+\" ties (i.e. continues or sustains) the sound for an additional sixteenth note. \"-\" rests (i.e. creates silence) for a sixteenth note."
+        }
+      },
+      "example": {
+        "python": "# Slice by default sixteenth notes\nsound = HIPHOP_DUSTYGROOVE_006\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\")",
+        "javascript": "// Slice by default sixteenth notes\nvar sound = HIPHOP_DUSTYGROOVE_006;\nmakeBeatSlice(sound, 1, 1, \"0122252289A2CCEC\");"
+      }
+    },
+
+    "makeBeatSlice2": {
       "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
       "parameters": {
         "sound": {
@@ -938,7 +960,7 @@
       }
     },
 
-    "makeBeatSlice2": {
+    "makeBeatSlice3": {
       "description": "Creates a rhythmic pattern through specifying a string of characters indicating the start position within a sound. Unlike makeBeat, which always plays sounds from the beginning, makeBeatSlice lets you create rhythms that combine many different slices of sound from the same sound.",
       "parameters": {
         "sound": {
@@ -963,6 +985,19 @@
       "example": {
         "python": "# Slice and rearrange by eighth notes\nsound = HIPHOP_TRAPHOP_BEAT_002\neighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875]\nbeat = \"01261264\"\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8)",
         "javascript": "// Slice and rearrange by eighth notes\nvar sound = HIPHOP_TRAPHOP_BEAT_002;\nvar eighths = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 1.875];\nvar beat = \"01261264\";\nmakeBeatSlice(sound, 1, 1, beat, eighths, 8);"
+      }
+    },
+
+    "sliceEveryNth": {
+      "description": "Generates a list of slice start positions evenly spaced by note duration. For example, sliceEveryNth(16) returns positions spaced by sixteenth notes, and sliceEveryNth(8) returns positions spaced by eighth notes.",
+      "parameters": {
+        "n": {
+          "description": "The number of evenly spaced slices per measure. Use 16 for sixteenth notes, 8 for eighth notes, 4 for quarter notes."
+        }
+      },
+      "example": {
+        "python": "# Slice by eighth notes\nslices = sliceEveryNth(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
+        "javascript": "// Slice by eighth notes\nvar slices = sliceEveryNth(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
       }
     },
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -988,16 +988,19 @@
       }
     },
 
-    "sliceEveryNth": {
-      "description": "Generates a list of slice start positions evenly spaced by note duration. For example, sliceEveryNth(16) returns positions spaced by sixteenth notes, and sliceEveryNth(8) returns positions spaced by eighth notes.",
+    "slicesPerMeasure": {
+      "description": "Generates a list of slice start positions evenly spaced by note duration. For example, slicesPerMeasure(16) returns positions spaced by sixteenth notes, and slicesPerMeasure(8) returns positions spaced by eighth notes.",
       "parameters": {
         "n": {
           "description": "The number of evenly spaced slices per measure. Use 16 for sixteenth notes, 8 for eighth notes, 4 for quarter notes."
         }
       },
+      "returns": {
+        "description": "A list of slice start positions evenly spaced by note duration."
+      },
       "example": {
-        "python": "# Slice by eighth notes\nslices = sliceEveryNth(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
-        "javascript": "// Slice by eighth notes\nvar slices = sliceEveryNth(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
+        "python": "# Slice by eighth notes\nslices = slicesPerMeasure(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
+        "javascript": "// Slice by eighth notes\nvar slices = slicesPerMeasure(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
       }
     },
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -999,8 +999,8 @@
         "description": "A list of slice start positions evenly spaced by note duration."
       },
       "example": {
-        "python": "# Slice by eighth notes\nslices = slicesPerMeasure(8)\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices)",
-        "javascript": "// Slice by eighth notes\nvar slices = slicesPerMeasure(8);\nmakeBeatSlice(HIPHOP_DUSTYGROOVE_006, 1, 1, \"01261264\", slices);"
+        "python": "# Slice by sixteenth notes\nslices = slicesPerMeasure(16)\nmakeBeatSlice(CIARA_MELANIN_DRUMBEAT_1, 1, 1, \"0123012378C8CCCC\", slices)",
+        "javascript": "// Slice by sixteenth notes\nvar slices = slicesPerMeasure(16);\nmakeBeatSlice(CIARA_MELANIN_DRUMBEAT_1, 1, 1, \"0123012378C8CCCC\", slices);"
       }
     },
 


### PR DESCRIPTION
- sliceStarts is now optional, defaults to sliceInto(16)
- checkArgCount lowered from 5 to 4 minimum arguments
- Added sliceInto(nSlices) helper function
- Registered sliceInto in API_FUNCTIONS and rawDoc

Closes #1017
Closed #1053