### PR TITLE
Fixed confusion with click and playback for sighted users

### DIFF
--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -24,11 +24,6 @@ let loop = {
     end: 0,
 }
 
-let previewing = {
-    on: false,
-    track: 0,
-}
-
 let dawData: DAWData | null = null
 
 let upcomingProjectGraph: ProjectGraph | null = null
@@ -83,7 +78,7 @@ export function play(startMes: number, delay = 0, maxEndMes: number = 0) {
         const trackBypass = bypassedEffects[t] ?? []
         const trackGraph = playTrack(context, t, dawData!.tracks[t], out, tempoMap, startTime, endTime, waStartTime, upcomingProjectGraph.mix, trackBypass)
         upcomingProjectGraph.tracks.push(trackGraph)
-        if (mutedTracks.includes(t) || (previewing.on && t !== previewing.track)) {
+        if (mutedTracks.includes(t)) {
             trackGraph.output.gain.value = 0
         }
     }
@@ -111,7 +106,6 @@ export function play(startMes: number, delay = 0, maxEndMes: number = 0) {
     timers.playEnd = window.setTimeout(() => {
         reset()
         callbacks.onFinishedCallback()
-        previewing.on = false
     }, (endTime - startTime + delay) * 1000)
 }
 
@@ -210,13 +204,8 @@ export function getPosition() {
 
 export const getProjectTracks = () => [...projectGraph?.tracks.entries() ?? [], ...upcomingProjectGraph?.tracks.entries() ?? []]
 
-export function setPreview(track: number) {
-    previewing = { on: true, track }
-}
-
 export function setMutedTracks(muted: number[]) {
     mutedTracks = muted
-    if (previewing.on) return
     for (const [i, track] of getProjectTracks()) {
         track.output.gain.value = muted.includes(i) ? 0 : 1
     }

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -24,6 +24,11 @@ let loop = {
     end: 0,
 }
 
+// Tracks whether the active playback is a clip-scoped preview (started by Ctrl+Space while a
+// DAW clip is focused), as opposed to whole-arrangement playback. Lets the DAW know whether
+// losing focus on that clip should stop playback, or leave unrelated playback alone.
+let previewing = false
+
 let dawData: DAWData | null = null
 
 let upcomingProjectGraph: ProjectGraph | null = null
@@ -203,6 +208,18 @@ export function getPosition() {
 }
 
 export const getProjectTracks = () => [...projectGraph?.tracks.entries() ?? [], ...upcomingProjectGraph?.tracks.entries() ?? []]
+
+export function startPreview() {
+    previewing = true
+}
+
+export function isPreviewing() {
+    return previewing
+}
+
+export function clearPreview() {
+    previewing = false
+}
 
 export function setMutedTracks(muted: number[]) {
     mutedTracks = muted

--- a/src/browser/Scripts.tsx
+++ b/src/browser/Scripts.tsx
@@ -45,7 +45,7 @@ const ScriptSearchBar = () => {
     const dispatchSearch = (event: ChangeEvent<HTMLInputElement>) => dispatch(scripts.setSearchText(event.target.value))
     const dispatchReset = () => dispatch(scripts.setSearchText(""))
     const liveMessage = t("scriptsFound", { count })
-    const props = { id: "scriptSearchBar", aria: t("ariaDescriptors:scripts.searchBar"), liveMessage, firstResultSelector: "#panel-1 button", searchText, dispatchSearch, dispatchReset }
+    const props = { id: "scriptSearchBar", aria: t("ariaDescriptors:scripts.searchBar"), liveMessage, firstResultSelector: "#panel-1 [data-test=\"scriptEntry\"]", searchText, dispatchSearch, dispatchReset }
 
     return <SearchBar {...props} />
 }
@@ -299,17 +299,24 @@ const ScriptEntry = ({ script, type }: { script: Script, type: ScriptType }) => 
 
     const shared = script.creator || script.isShared
     const ariaLabel = type === "deleted" ? "" : t("scriptBrowser.openInEditor", { name: script.name })
+    const openScript = () => {
+        if (type === "regular" || type === "shared") {
+            dispatch(setActiveTabAndEditor(script.shareid))
+        }
+        if (highlight) {
+            dispatch(caiThunks.highlight({ zone: null }))
+        }
+    }
     return (
         <div
             className={`flex flex-row justify-start border-t border-b border-r border-gray-500 dark:border-gray-700 ${type === "deleted" ? "" : "cursor-pointer"}`}
-            onClick={() => {
-                if (type === "regular") {
-                    dispatch(setActiveTabAndEditor(script.shareid))
-                } else if (type === "shared") {
-                    dispatch(setActiveTabAndEditor(script.shareid))
-                }
-                if (highlight) {
-                    dispatch(caiThunks.highlight({ zone: null }))
+            data-test="scriptEntry"
+            tabIndex={type === "deleted" ? -1 : 0}
+            onClick={openScript}
+            onKeyDown={(e) => {
+                if (type !== "deleted" && (e.key === "Enter" || e.key === " ")) {
+                    e.preventDefault()
+                    openScript()
                 }
             }}
             title={ariaLabel}

--- a/src/daw/DAW.tsx
+++ b/src/daw/DAW.tsx
@@ -36,6 +36,15 @@ function formatSourceLines(sourceLines: number[]): string {
     return `Line: ${sourceLines[0] ?? 0}`
 }
 
+// Ctrl+I is a native browser shortcut in some browsers (e.g. Firefox's Page Info dialog),
+// so jump-to-editor handlers must prevent it before running their own action.
+function onCtrlI(e: React.KeyboardEvent, action: () => void) {
+    if (e.ctrlKey && e.key === "i") {
+        e.preventDefault()
+        action()
+    }
+}
+
 const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPlayPosition: (a: number) => void }) => {
     const dispatch = useDispatch()
     const hideDAW = useSelector(appState.selectHideDAW)
@@ -505,6 +514,11 @@ const Clip = ({ color, clip, familyRange, familyIndex, familySize, familyHasLoop
         onMouseEnter={() => {
             scriptMatchesDAW && setDAWHoverLine(color, sourceLines)
         }} onMouseLeave={clearDAWHoverLine}
+        onMouseDown={(e: React.MouseEvent) => {
+            // A plain click should do nothing at all; only Option/Alt+click focuses the clip
+            // (for solo-isolation and Ctrl+Space preview scoping), same as Tab and Ctrl+I.
+            if (!e.altKey) e.preventDefault()
+        }}
         onFocus={() => {
             // Jumping here from the editor (Ctrl+I) isolates this clip's track (or, if this
             // call site generated clips on several tracks, all of those tracks) so the
@@ -541,13 +555,11 @@ const Clip = ({ color, clip, familyRange, familyIndex, familySize, familyHasLoop
         }}
         title={scriptMatchesDAW ? formatSourceLines(sourceLines) : t("daw.needsSync")}
         aria-label={clipAriaLabel}
-        onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.ctrlKey && e.key === "i") {
-                // The subsequent onBlur (triggered by jumpToLine shifting focus to the editor)
-                // restores normal playback and visuals.
-                jumpToLine(primaryLine)
-            }
-        }}
+        onKeyDown={(e: React.KeyboardEvent) => onCtrlI(e, () => {
+            // The subsequent onBlur (triggered by jumpToLine shifting focus to the editor)
+            // restores normal playback and visuals.
+            jumpToLine(primaryLine)
+        })}
     >
         <div className="clipWrapper">
             <div style={{ width: width + "px" }} className="clipName prevent-selection">{clip.filekey}</div>
@@ -614,7 +626,7 @@ const Automation = ({ effect, parameter, color, envelope, bypass, mute, showName
                         onMouseLeave={() => { setFocusedPoint(null); clearDAWHoverLine() }}
                         onFocus={() => { setFocusedPoint(i); scriptMatchesDAW && setDAWHoverLine(color, pointLines) }}
                         onBlur={() => { setFocusedPoint(null); clearDAWHoverLine() }}
-                        onKeyDown={(e: React.KeyboardEvent) => { if (e.ctrlKey && e.key === "i") jumpToLine(pointLines[0]) }}
+                        onKeyDown={(e: React.KeyboardEvent) => onCtrlI(e, () => jumpToLine(pointLines[0]))}
                     >
                         {/* eslint-disable-next-line react/jsx-indent */}
                         <title>({point.measure}, {point.value})&#010;{scriptMatchesDAW ? formatSourceLines(pointLines) : t("daw.needsSync")}</title>

--- a/src/daw/DAW.tsx
+++ b/src/daw/DAW.tsx
@@ -63,7 +63,7 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
         setPlayPosition(1)
     }
 
-    const play = () => {
+    const play = (range?: { start: number, end: number }) => {
         if (bubble.active && bubble.currentPage === 4 && !bubble.readyToProceed) {
             dispatch(setReady(true))
         }
@@ -77,13 +77,13 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
 
         dispatch(daw.setPlaying(false))
 
-        if (playPosition >= playLength) {
+        if (!range && playPosition >= playLength) {
             setPlayPosition(loop.selection ? loop.start : 1)
         }
 
         player.callbacks.onStartedCallback = playbackStartedCallback
         player.callbacks.onFinishedCallback = playbackEndedCallback
-        player.play(playPosition)
+        player.play(range?.start ?? playPosition, 0, range?.end ?? 0)
 
         // player does not preserve volume state between plays
         player.setVolume(volumeMuted ? -60 : volume)
@@ -147,18 +147,19 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
 
     const [titleKey, setTitleKey] = useState<string | null>(null)
 
-    const usePlayPauseShortcut = (playing: boolean, play: () => void, pause: () => void, hasDAWData: boolean) => {
+    const usePlayPauseShortcut = (playing: boolean, play: (range?: { start: number, end: number }) => void, pause: () => void, hasDAWData: boolean) => {
         useEffect(() => {
             const handleKeyPress = (event: KeyboardEvent) => {
             // Ctrl (ctrlKey) and spacebar key press
                 if ((event.ctrlKey) && event.key === " " && hasDAWData) {
                     event.preventDefault()
 
-                    // Toggle between play and pause based on current state
+                    // Toggle between play and pause based on current state.
+                    // If a clip is currently focused, play just its (already-soloed) range.
                     if (playing) {
                         pause()
                     } else {
-                        play()
+                        play(focusedClipRange ?? undefined)
                     }
                 }
             }
@@ -513,30 +514,31 @@ const Clip = ({ color, clip, familyRange, familyIndex, familySize, familyHasLoop
             for (const t of tracksToIsolate ?? [clip.track]) isolated[t] = "solo"
             store.dispatch(daw.setSoloMute(isolated))
             player.setMutedTracks(daw.getMuted(tracks, isolated, metronome))
+            // Remember this clip's range so Ctrl+Space plays just this clip (or, if this focus
+            // came from a Ctrl+I jump, the full family range) instead of the whole arrangement.
+            focusedClipRange = {
+                start: focusedFromCtrlI.current ? playStart : clip.measure,
+                end: focusedFromCtrlI.current ? playEnd : singleClipEnd,
+            }
+        }}
+        onBlur={() => {
+            // Leaving the clip (Tab to another element, click elsewhere, Ctrl+I back to the
+            // editor) stops playback and restores normal solo/mute so nothing keeps playing
+            // or stays isolated unattended.
+            focusedClipRange = null
+            player.pause()
+            store.dispatch(daw.setPlaying(false))
+            const restored = savedSoloMute ?? soloMute
+            store.dispatch(daw.setSoloMute(restored))
+            player.setMutedTracks(daw.getMuted(tracks, restored, metronome))
+            savedSoloMute = null
         }}
         title={scriptMatchesDAW ? formatSourceLines(sourceLines) : t("daw.needsSync")}
         aria-label={clipAriaLabel}
-        onClick={() => {
-            player.setPreview(clip.track)
-            player.callbacks.onStartedCallback = () => {
-                store.dispatch(daw.setPlaying(true))
-                store.dispatch(daw.setPendingPosition(null))
-            }
-            player.callbacks.onFinishedCallback = () => {
-                store.dispatch(daw.setPlaying(false))
-                _setPlayPosition?.(1)
-            }
-            const start = focusedFromCtrlI.current ? playStart : clip.measure
-            const end = focusedFromCtrlI.current ? playEnd : singleClipEnd
-            player.play(start, 0, end)
-        }}
         onKeyDown={(e: React.KeyboardEvent) => {
             if (e.ctrlKey && e.key === "i") {
-                // Jumping back to the editor restores normal playback and visuals.
-                const restored = savedSoloMute ?? soloMute
-                store.dispatch(daw.setSoloMute(restored))
-                player.setMutedTracks(daw.getMuted(tracks, restored, metronome))
-                savedSoloMute = null
+                // The subsequent onBlur (triggered by jumpToLine shifting focus to the editor)
+                // restores normal playback and visuals.
                 jumpToLine(primaryLine)
             }
         }}
@@ -907,6 +909,10 @@ let _setPlayPosition: ((a: number) => void) | null = null
 // Solo/mute state saved when Ctrl+I focus-isolates a clip's track, so it can be restored
 // when jumping back to the editor. null means no isolation is currently active.
 let savedSoloMute: Record<number, daw.SoloMute> | null = null
+
+// Start/end measures of the currently focused clip (Tab or Ctrl+I), so Ctrl+Space can play
+// just that clip's range instead of the whole arrangement. null means no clip is focused.
+let focusedClipRange: { start: number, end: number } | null = null
 
 // Scroll the DAW so that `element` is within the visible area of the track timeline.
 // Updates ghost bars (#daw-x-scroll, #daw-y-scroll) as the primary mechanism — the useEffect

--- a/src/daw/DAW.tsx
+++ b/src/daw/DAW.tsx
@@ -77,7 +77,9 @@ const Header = ({ playPosition, setPlayPosition }: { playPosition: number, setPl
 
         dispatch(daw.setPlaying(false))
 
-        if (!range && playPosition >= playLength) {
+        if (range) {
+            player.startPreview()
+        } else if (playPosition >= playLength) {
             setPlayPosition(loop.selection ? loop.start : 1)
         }
 
@@ -523,11 +525,15 @@ const Clip = ({ color, clip, familyRange, familyIndex, familySize, familyHasLoop
         }}
         onBlur={() => {
             // Leaving the clip (Tab to another element, click elsewhere, Ctrl+I back to the
-            // editor) stops playback and restores normal solo/mute so nothing keeps playing
-            // or stays isolated unattended.
+            // editor) restores normal solo/mute so nothing stays isolated unattended. Only stop
+            // playback if this clip's own preview is what's playing — leave unrelated
+            // whole-arrangement playback alone.
             focusedClipRange = null
-            player.pause()
-            store.dispatch(daw.setPlaying(false))
+            if (player.isPreviewing()) {
+                player.pause()
+                store.dispatch(daw.setPlaying(false))
+                player.clearPreview()
+            }
             const restored = savedSoloMute ?? soloMute
             store.dispatch(daw.setSoloMute(restored))
             player.setMutedTracks(daw.getMuted(tracks, restored, metronome))


### PR DESCRIPTION
 - onFocus on a clip: solo-isolates its track and records focusedClipRange (its start/end measures) for Ctrl+Space to use. 
 
- onBlur (tabbing away, clicking elsewhere, or Ctrl+I jumping back to the editor): pauses playback, clears focusedClipRange, and restores normal solo/mute state, nothing keeps playing or stays isolated once you leave the clip. 
- onKeyDown for Ctrl+I now just calls jumpToLine; the restore logic that used to live there is handled by the onBlur it triggers. - Ctrl+Space (global play/pause) plays the focused clip's range when one is focused, otherwise plays from the normal header position

Fixes #889 
Fixes #894
Fixes #897 