### PR TITLE
Fix missing hover style on even rows in script browser

### DIFF
--- a/src/browser/Scripts.tsx
+++ b/src/browser/Scripts.tsx
@@ -371,7 +371,7 @@ const WindowedScriptCollection = ({ title, entities, scriptIDs, type, visible = 
                 data={scriptIDs}
                 itemContent={(index, ID) => (
                     <div className={index % 2 === 0
-                        ? "bg-white dark:bg-gray-900"
+                        ? "bg-white dark:bg-gray-900 hover:bg-blue-100 dark:hover:bg-blue-500"
                         : "bg-gray-300 dark:bg-gray-800 hover:bg-blue-200 dark:hover:bg-blue-500"}>
                         <ScriptEntry script={entities[ID]} type={type} />
                     </div>


### PR DESCRIPTION
Simply added the hover feature, which had the odd rows, to the even rows too. 