### PR TITLE
Use fake timers for sourceHighlight vitests

### DIFF
--- a/tests/vitest/src/daw/sourceHighlight.spec.jsx
+++ b/tests/vitest/src/daw/sourceHighlight.spec.jsx
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it, vi } from "vitest"
+import { afterAll, beforeAll, beforeEach, expect, it, vi } from "vitest"
 import { Provider } from "react-redux"
 import { render, waitFor } from "@testing-library/react"
 import d3 from "d3"
@@ -12,6 +12,14 @@ import { setEditorCursorLine, setScriptMatchesDAW } from "../../../../src/ide/id
 
 window.d3 = d3
 window.ResizeObserver = ResizeObserver
+
+// jsdom simulates requestAnimationFrame via a real setTimeout. If a rAF is
+// pending when the jsdom document is destroyed at suite teardown, it fires
+// against a null document and throws. Faking only rAF/cancelAnimationFrame
+// prevents that real setTimeout from ever being scheduled, while leaving
+// waitFor's setTimeout/setInterval untouched.
+beforeAll(() => { vi.useFakeTimers({ toFake: ["requestAnimationFrame", "cancelAnimationFrame"] }) })
+afterAll(() => { vi.useRealTimers() })
 
 vi.mock("react-i18next")
 vi.mock("../../../../src/app/audiolibrary")


### PR DESCRIPTION
the DAW's ResizeObserver callback schedules a requestAnimationFrame, but jsdom implements rAF via a real setTimeout(~16ms). After the last test finishes and jsdom tears down the document, that pending setTimeout fires and tries to access window.location on the now-null document.

The fix is to fake only requestAnimationFrame/cancelAnimationFrame for this test file, so jsdom never schedules a real setTimeout for rAF — waitFor's own setTimeout/setInterval remain real and unaffected.