### PR TITLE
Enable focus shortcut for extension

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,7 +55,7 @@ import { status as consoleStatus } from "../ide/console"
 import { playEarcon, SINE_BUMP } from "../audio/earcon"
 import { pushFocus, updateNewerFocus, stepBackward, stepForward, selectNewerFocus, selectAtNavOffset, FocusRecord } from "./focusHistoryState"
 import { ExtensionLoader } from "../extensions/ExtensionLoader"
-import { clearExtension } from "../extensions/extensionState"
+import { clearExtension, selectExtensionUrl } from "../extensions/extensionState"
 
 // TODO: Temporary workaround for autograder and code analyzer, which replace the prompt function.
 (window as any).esPrompt = async (message: string) => {
@@ -113,8 +113,12 @@ export function navigateTo(entry: PanelEntry) {
         })
     } else if ("elementSelector" in entry) {
         if (entry.panel === "west") entry.onBeforeFocus?.()
+        const isExtensionPaneActive = entry.panel === "east" &&
+            appState.selectEastContent(store.getState()) === "extension" &&
+            selectExtensionUrl(store.getState()) !== ""
+        const elementSelector = isExtensionPaneActive ? "#extensionTitleBar" : entry.elementSelector
         window.requestAnimationFrame(() => {
-            const el = document.querySelector(entry.elementSelector) as HTMLElement | null
+            const el = document.querySelector(elementSelector) as HTMLElement | null
             el?.focus()
         })
     }

--- a/src/extensions/ExtensionHost.tsx
+++ b/src/extensions/ExtensionHost.tsx
@@ -135,7 +135,7 @@ export const ExtensionHost = () => {
             <div dir={currentLocale.direction} className={`h-full ${paneIsOpen ? "" : "hidden"}`}>
                 <TitleBar isCurriculumPane={false} />
                 <div className="w-full flex justify-between items-stretch select-none text-white bg-blue">
-                    <div className="flex items-center gap-2 p-2.5 text-amber">
+                    <div id="extensionTitleBar" tabIndex={-1} className="flex items-center gap-2 p-2.5 text-amber">
                         {extensionIcon32 && <img src={extensionIcon32} alt="" className="w-5 h-5 border border-gray-300 dark:border-gray-400 rounded" />}
                         <span>{extensionName.toLocaleUpperCase()}</span>
                     </div>


### PR DESCRIPTION
Switch the curriculum navigation shortcut (Ctrl + Shift + 6) to work for the extension panel when an extension is showing.