### PR TITLE
Override codemirror shortcuts for focus history navigation

### DIFF
--- a/src/ide/Editor.tsx
+++ b/src/ide/Editor.tsx
@@ -344,9 +344,12 @@ export function createSession(id: string, language: Language, contents: string) 
                 ...keyBindings,
             ]),
             // NOTE: Avoid the default autocomplete trigger when ctrl+space is used in the code editor
+            // Also avoid basicSetup's foldKeymap stealing Ctrl-Alt-[/] from the global focus-history shortcut.
             Prec.highest(
                 keymap.of([
                     { key: "Ctrl-Space", run: () => { return true } },
+                    { key: "Ctrl-Alt-[", run: () => { return true } },
+                    { key: "Ctrl-Alt-]", run: () => { return true } },
                 ])
             ),
             EditorView.updateListener.of(update => {


### PR DESCRIPTION
Codemirror `basicSetup` bundles Ctrl + Alt + [ / ] to collapse and expand all code sections.

This PR overrides these so we can use them for focus history traversal.