### PR TITLE
Validate makeBeatSlice sliceStarts

### DIFF
--- a/src/api/passthrough.ts
+++ b/src/api/passthrough.ts
@@ -306,6 +306,11 @@ export function makeBeatSlice(result: DAWData, soundConstant: string, track: num
     checkRange("start", start, { min: 1 })
     checkRange("stepsPerMeasure", stepsPerMeasure, { min: 1 / 1024, max: 256 })
 
+    for (const sliceStart of sliceStarts) {
+        checkType("sliceStarts", "number", sliceStart)
+        checkRange("sliceStarts", sliceStart, { min: 1 })
+    }
+
     stepsPerMeasure = 1.0 / stepsPerMeasure
 
     const SUSTAIN = "+"


### PR DESCRIPTION
Fixes #926.

This adds validation to ensure every value in the sliceStarts array is a number greater than or equal to 1 before processing makeBeatSlice. This prevents invalid sliceStarts values from reaching the audio engine and causing the application to crash.