### PR TITLE
Increment audio-standard to bust cache

### DIFF
--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -125,7 +125,7 @@ export function getStandardSounds() {
 async function _getStandardSounds() {
     esconsole("Fetching standard sound metadata", ["debug", "audiolibrary"])
     try {
-        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard_2.json"
+        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard_3.json"
         const response = await fetch(url)
         if (!response.ok) {
             throw Object.assign(new Error(`Failed to fetch standard sounds (code ${response.status}).`), { code: response.status })

--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -125,7 +125,7 @@ export function getStandardSounds() {
 async function _getStandardSounds() {
     esconsole("Fetching standard sound metadata", ["debug", "audiolibrary"])
     try {
-        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard_3.json"
+        const url = STATIC_AUDIO_URL_DOMAIN + "/audio-standard_4.json"
         const response = await fetch(url)
         if (!response.ok) {
             throw Object.assign(new Error(`Failed to fetch standard sounds (code ${response.status}).`), { code: response.status })

--- a/tests/playwright/helpers/mocks.ts
+++ b/tests/playwright/helpers/mocks.ts
@@ -111,7 +111,7 @@ export async function setupBackend(page: Page, opts: MockOptions = {}): Promise<
 
     // Standard audio library — always set if anything is mocked
     const standardAudio = standardLibraryDefault(opts.standardAudio ?? [])
-    await page.route(`https://${CLOUDFRONT_HOST}/backend-static/audio-standard_3.json`, (route) => {
+    await page.route(`https://${CLOUDFRONT_HOST}/backend-static/audio-standard_4.json`, (route) => {
         counter.bump("audio_standard")
         return fulfillJson(route, standardAudio)
     })

--- a/tests/playwright/helpers/mocks.ts
+++ b/tests/playwright/helpers/mocks.ts
@@ -111,7 +111,7 @@ export async function setupBackend(page: Page, opts: MockOptions = {}): Promise<
 
     // Standard audio library — always set if anything is mocked
     const standardAudio = standardLibraryDefault(opts.standardAudio ?? [])
-    await page.route(`https://${CLOUDFRONT_HOST}/backend-static/audio-standard_2.json`, (route) => {
+    await page.route(`https://${CLOUDFRONT_HOST}/backend-static/audio-standard_3.json`, (route) => {
         counter.bump("audio_standard")
         return fulfillJson(route, standardAudio)
     })


### PR DESCRIPTION
Made the latest json available, now using `type=2` for hidden sounds.

Now hidden sounds can be referenced by a script, but will not show in the sound browser.

Relates to https://github.com/earsketch/earsketch-api/issues/129