### PR TITLE
Exclude unnecessary parameter when fetching user sounds

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -969,7 +969,7 @@ export const App = () => {
 
                 store.dispatch(user.login({ username, token }))
 
-                store.dispatch(soundsThunks.getUserSounds(username))
+                store.dispatch(soundsThunks.getUserSounds())
                 store.dispatch(soundsThunks.getFavorites(token))
 
                 // Always override with the returned username in case the letter cases mismatch.

--- a/src/app/SoundUploader.tsx
+++ b/src/app/SoundUploader.tsx
@@ -97,7 +97,7 @@ async function uploadFile(username: string | null, file: Blob, name: string, ext
                     // Clear the cache so it gets reloaded.
                     audioLibrary.clearCache()
                     store.dispatch(sounds.resetUserSounds())
-                    store.dispatch(getUserSounds(username!))
+                    store.dispatch(getUserSounds())
                     resolve()
                 } else {
                     reject(i18n.t("messages:uploadcontroller.commerror"))
@@ -339,7 +339,7 @@ const FreesoundTab = ({ close }: { close: () => void }) => {
             // Clear the cache so it gets reloaded.
             audioLibrary.clearCache()
             store.dispatch(sounds.resetUserSounds())
-            store.dispatch(getUserSounds(username))
+            store.dispatch(getUserSounds())
             close()
         } catch (error: any) {
             setError(error.message)

--- a/src/app/audiolibrary.ts
+++ b/src/app/audiolibrary.ts
@@ -150,9 +150,9 @@ async function _getStandardSounds() {
     }
 }
 
-export async function getUserSounds(username: string) {
+export async function getUserSounds() {
     // The /audio/user depricated query parameter `username` is maintained, for now, until the backend is updated.
-    const sounds: SoundEntity[] = await getAuth("/audio/user", { username })
+    const sounds: SoundEntity[] = await getAuth("/audio/user")
     // Populate cache with user sound metadata so that we don't fetch it again later via `getMetadata()`.
     for (const sound of sounds) {
         fixMetadata(sound)

--- a/src/browser/soundsThunks.ts
+++ b/src/browser/soundsThunks.ts
@@ -41,10 +41,10 @@ export const getStandardSounds = createAsyncThunk<void, void, ThunkAPI>(
     }
 )
 
-export const getUserSounds = createAsyncThunk<void, string, ThunkAPI>(
+export const getUserSounds = createAsyncThunk<void, void, ThunkAPI>(
     "sounds/getUserSounds",
-    async (username, { dispatch }) => {
-        const data = await audioLibrary.getUserSounds(username)
+    async (_, { dispatch }) => {
+        const data = await audioLibrary.getUserSounds()
         const entities: { [key: string]: SoundEntity; } = {}
         const names = new Array(data.length)
         for (const [i, sound] of data.entries()) {

--- a/tests/playwright/helpers/mocks.ts
+++ b/tests/playwright/helpers/mocks.ts
@@ -159,7 +159,7 @@ export async function setupBackend(page: Page, opts: MockOptions = {}): Promise<
     }
 
     if (opts.userAudio !== undefined) {
-        await page.route(`https://${API_HOST}/EarSketchWS/audio/user?**`, (route) => {
+        await page.route(`https://${API_HOST}/EarSketchWS/audio/user`, (route) => {
             counter.bump("audio_user")
             return fulfillJson(route, opts.userAudio)
         })

--- a/tests/vitest/src/app/audiolibrary.spec.ts
+++ b/tests/vitest/src/app/audiolibrary.spec.ts
@@ -24,7 +24,7 @@ it("defaults an undefined sound type to hidden without replacing an explicit typ
     } as SoundEntity
     vi.mocked(getAuth).mockResolvedValue([withoutType, publicSound])
 
-    const sounds = await getUserSounds("tester")
+    const sounds = await getUserSounds()
 
     expect(sounds[0].type).toBe(SoundType.Hidden)
     expect(sounds[0].tempo).toBeUndefined()


### PR DESCRIPTION
This pr finishes the effort to remove the `?username=` query parameter from the `/audio/user` endpoint.

The username is communicated by the auth token already, which is where the backend gets it from now.

This is motivated by the fact that this is a GET, so the query parameter is part of the url and may get logged.

Relates to earsketch/earsketch-webclient#723
Relates to earsketch/earsketch-api#92